### PR TITLE
Revert "fix: interleave inference smart resize pixel (#68)"

### DIFF
--- a/examples/interleave/inference.py
+++ b/examples/interleave/inference.py
@@ -80,7 +80,7 @@ def smart_resize(
     width: int,
     factor: int = 32,
     min_pixels: int = 512 * 512,
-    max_pixels: int = (4 * 2048 * 2048) // 4,
+    max_pixels: int = (4 * 2048 * 2048) // 8,
 ) -> tuple[int, int]:
     """Return ``(h, w)`` that are divisible by ``factor``, keep aspect ratio,
     and fall inside ``[min_pixels, max_pixels]``.


### PR DESCRIPTION
This reverts commit 08fd224892f583c31c270e5e9e9e075d191820e8.