### PR TITLE
fix: anchor models/ gitignore pattern to prevent excluding Python subpackage from wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ ENV/
 # Submodules (LightLLM, EASI) + patches/ are tracked — nothing to ignore there.
 # Models dir (./models/) weights excluded via *.safetensors below.
 evaluation/easi/logs/
-models/
+/models/
 
 # uv
 .uv/


### PR DESCRIPTION
Issue:  `pip install .` produces a broken wheel — `import sensenova_u1` fails with `ModuleNotFoundError: No module named 'sensenova_u1.models'`.

Root Cause: Hatchling (current PEP 517 build backend) honours `.gitignore` by default when deciding which files to include in the wheel. The bare `models/` entry matched every directory named `models` at any depth, silently dropping the  entire `src/sensenova_u1/models/` subpackage from the wheel.

Fix: Changed `models/` → `/models/` in `.gitignore`. The leading `/` anchors the pattern to the repository root, so the top-level weights directory remains ignored while the Python subpackage is correctly included in the build.