### PR TITLE
feat(editing): add image prefix when there are multiple images & reduce max VRAM usage

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -184,6 +184,14 @@ Output resolution has two modes:
 - **Auto (default)**: omit `--width / --height` — output tracks the first input via `smart_resize` (aspect ratio preserved, total pixels normalized to `--target_pixels` default `2048 * 2048`, H / W snapped to multiples of 32).
 - **Explicit**: pass `--width W --height H` (both multiples of 32). 2048 × 2048 is a good general-purpose choice.
 
+For best editing quality, provide high-resolution input/reference images when possible.
+Use `--input_max_pixels auto` to keep up to two inputs at 2048 × 2048 and divide that total budget across more inputs.
+This is a conservative default based on a two-reference 2048 × 2048 memory budget;
+tune the cap for your GPU memory and quality needs, or pass an integer such as `1048576` for a 1024 × 1024 cap.
+Resize-to-budget is enabled by default; pass `--no-do-resize` to skip this outer resize step.
+The model's native preprocessing still applies its own input limits.
+The script prints the per-image input cap before generation.
+
 CFG defaults: `--cfg_scale 4.0` (text guidance), `--img_cfg_scale 1.0` (image CFG off by default). Run `python examples/editing/inference.py --help` for the full flag list.
 
 See [`editing/data/samples.jsonl`](./editing/data/samples.jsonl) for a tiny starter file.

--- a/examples/README_CN.md
+++ b/examples/README_CN.md
@@ -176,6 +176,13 @@ python examples/editing/inference.py \
 - **自动模式（默认）**：不传 `--width / --height` 时，输出分辨率跟随第一张输入图，通过 `smart_resize` 保持宽高比，总像素数归一化到 `--target_pixels`（默认 `2048 * 2048`），且 H / W 均对齐到 32 的倍数。
 - **显式指定**：传入 `--width W --height H`（二者均须为 32 的倍数）。2048 × 2048 是一个通用场景下的稳妥选择。
 
+为了获得更好的编辑质量，建议尽量提供高分辨率输入/参考图。
+显存有限时可使用 `--input_max_pixels auto`：1-2 张图保持单图最高2048 × 2048，超过 2 张时把两张 2048 × 2048 的总预算均分给所有输入图。
+这个策略是基于“两张 2048 × 2048 参考图”的显存预算给出的保守默认值；
+可根据自己的显卡显存和编辑效果调节，也可传入整数，例如 `1048576` 表示单张输入图最高约 1024 × 1024。
+外层 resize-to-budget 默认开启；可传 `--no-do-resize` 跳过这一步，但模型原生图像预处理仍会应用自己的输入尺寸限制。
+脚本会在生成前打印每张输入图的上限。
+
 CFG 默认值：`--cfg_scale 4.0`（文本引导强度），`--img_cfg_scale 1.0`（默认关闭图像 CFG）。完整参数列表请运行 `python examples/editing/inference.py --help` 查看。
 
 可参考 [`editing/data/samples.jsonl`](./editing/data/samples.jsonl) 中的精简起步样例。

--- a/examples/editing/inference.py
+++ b/examples/editing/inference.py
@@ -28,16 +28,59 @@ DEFAULT_SEED = 42
 # Output H / W must be divisible by this (= patch_size * merge_size).
 _IMAGE_GRID_FACTOR = DEFAULT_IMAGE_PATCH_SIZE
 
-# aspect ratio ispreserved, total pixels are normalized to this target
+# Aspect ratio is preserved, total output pixels are normalized to this target.
 DEFAULT_TARGET_PIXELS = 2048 * 2048
+DEFAULT_INPUT_MAX_PIXELS = 2048 * 2048
+MIN_INPUT_MAX_PIXELS = 512 * 512
 
 
-def resize_to_target_pixels(img: Image.Image, target_pixels: int) -> Image.Image:
-    w, h = img.size
-    scale = math.sqrt(target_pixels / (w * h))
-    new_w = max(1, round(w * scale))
-    new_h = max(1, round(h * scale))
-    return img.resize((new_w, new_h), Image.LANCZOS)
+def _auto_input_max_pixels(num_images: int) -> int:
+    full_res_image_budget = 2
+    if num_images <= full_res_image_budget:
+        return DEFAULT_INPUT_MAX_PIXELS
+    total_budget = full_res_image_budget * DEFAULT_INPUT_MAX_PIXELS
+    return max(MIN_INPUT_MAX_PIXELS, total_budget // max(1, num_images))
+
+
+def _resolve_input_max_pixels(value: str | None, num_images: int) -> int | None:
+    if value is None:
+        return None
+    if value == "auto":
+        return _auto_input_max_pixels(num_images)
+    try:
+        input_max_pixels = int(value)
+    except ValueError as exc:
+        raise SystemExit("--input_max_pixels must be an integer or 'auto'.") from exc
+    if input_max_pixels < MIN_INPUT_MAX_PIXELS:
+        side = int(math.sqrt(MIN_INPUT_MAX_PIXELS))
+        raise SystemExit(f"--input_max_pixels must be >= {MIN_INPUT_MAX_PIXELS} ({side}*{side}).")
+    return input_max_pixels
+
+
+def _resize_to_max_budget(img: Image.Image, input_max_pixels: int) -> Image.Image:
+    resized_h, resized_w = smart_resize(
+        height=img.height,
+        width=img.width,
+        factor=_IMAGE_GRID_FACTOR,
+        min_pixels=input_max_pixels,
+        max_pixels=input_max_pixels,
+    )
+    if (resized_w, resized_h) == img.size:
+        return img
+    return img.resize((resized_w, resized_h), Image.LANCZOS)
+
+
+def _print_input_resize_hint(num_images: int, input_max_pixels: int | None, source: str, do_resize: bool) -> None:
+    if not do_resize:
+        print("[editing] resize-to-budget disabled; model preprocessing will still enforce its input limits.")
+        return
+    if input_max_pixels is None:
+        return
+    side = int(math.sqrt(input_max_pixels))
+    print(
+        f"[editing] {num_images} input image(s); {source} input_max_pixels={input_max_pixels} "
+        f"(about {side}x{side} per image, aspect ratio preserved)."
+    )
 
 
 def _denorm(x: torch.Tensor) -> torch.Tensor:
@@ -53,22 +96,38 @@ def _to_pil(batch: torch.Tensor) -> list[Image.Image]:
 
 
 def _load_input_image(
-    path: str | Path, do_resize: bool = True, target_pixels: int = DEFAULT_TARGET_PIXELS
+    path: str | Path,
+    *,
+    do_resize: bool,
+    input_max_pixels: int | None,
 ) -> Image.Image:
     """Load as RGB; flatten RGBA onto white so the generator sees a clean canvas."""
     img = Image.open(path)
     if img.mode == "RGBA":
         bg = Image.new("RGB", img.size, (255, 255, 255))
         bg.paste(img, mask=img.split()[3])
-    if do_resize:
-        img = resize_to_target_pixels(img, target_pixels=target_pixels)
-    return img.convert("RGB")
+    img = img.convert("RGB")
+    if do_resize and input_max_pixels is not None:
+        img = _resize_to_max_budget(img, input_max_pixels)
+    return img
 
 
 def _coerce_image_paths(value: object) -> list[str]:
     if isinstance(value, list):
         return [str(v) for v in value]
     return [str(value)]
+
+
+def _coerce_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    raise SystemExit(f"Expected a boolean value for do_resize, got {value!r}.")
 
 
 def _check_grid_divisible(width: int, height: int) -> None:
@@ -238,6 +297,28 @@ def parse_args() -> argparse.Namespace:
             "Ignored when --width / --height are given."
         ),
     )
+    p.add_argument(
+        "--input_max_pixels",
+        default="auto",
+        help=(
+            "Maximum pixels per input/reference image before vision encoding. "
+            "Use an integer (for example 1048576 for 1024*1024) or 'auto' to "
+            "keep up to two inputs at 2048*2048 and divide that total budget across more inputs. "
+            "Default: auto."
+        ),
+    )
+    p.add_argument(
+        "--do_resize",
+        "--do-resize",
+        dest="do_resize",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Whether to resize input/reference images to the input pixel budget before model preprocessing. "
+            "Enabled by default. If disabled, the model's native image preprocessing still applies its "
+            "own size limits."
+        ),
+    )
 
     p.add_argument(
         "--cfg_scale",
@@ -360,7 +441,12 @@ def main() -> None:
     cli_explicit_size: tuple[int, int] | None = (args.width, args.height) if args.width is not None else None
 
     if args.prompt is not None:
-        images = [_load_input_image(p, target_pixels=args.target_pixels) for p in args.image]
+        input_max_pixels = _resolve_input_max_pixels(args.input_max_pixels, len(args.image))
+        _print_input_resize_hint(len(args.image), input_max_pixels, args.input_max_pixels or "model-default", args.do_resize)
+        images = [
+            _load_input_image(p, do_resize=args.do_resize, input_max_pixels=input_max_pixels)
+            for p in args.image
+        ]
         w, h = _resolve_output_size(
             images,
             explicit=cli_explicit_size,
@@ -408,7 +494,19 @@ def main() -> None:
 
     for i, sample in enumerate(tqdm(samples, desc="Editing")):
         paths = _coerce_image_paths(sample["image"])
-        images = [_load_input_image(p, target_pixels=args.target_pixels) for p in paths]
+        sample_input_max_pixels = sample.get("input_max_pixels", args.input_max_pixels)
+        sample_do_resize = _coerce_bool(sample.get("do_resize", args.do_resize))
+        input_max_pixels = _resolve_input_max_pixels(str(sample_input_max_pixels), len(paths))
+        _print_input_resize_hint(
+            len(paths),
+            input_max_pixels,
+            str(sample_input_max_pixels or "model-default"),
+            sample_do_resize,
+        )
+        images = [
+            _load_input_image(p, do_resize=sample_do_resize, input_max_pixels=input_max_pixels)
+            for p in paths
+        ]
         w, h = _resolve_output_size(
             images,
             explicit=_explicit_size_from_sample(sample) or cli_explicit_size,

--- a/examples/editing/inference.py
+++ b/examples/editing/inference.py
@@ -442,11 +442,10 @@ def main() -> None:
 
     if args.prompt is not None:
         input_max_pixels = _resolve_input_max_pixels(args.input_max_pixels, len(args.image))
-        _print_input_resize_hint(len(args.image), input_max_pixels, args.input_max_pixels or "model-default", args.do_resize)
-        images = [
-            _load_input_image(p, do_resize=args.do_resize, input_max_pixels=input_max_pixels)
-            for p in args.image
-        ]
+        _print_input_resize_hint(
+            len(args.image), input_max_pixels, args.input_max_pixels or "model-default", args.do_resize
+        )
+        images = [_load_input_image(p, do_resize=args.do_resize, input_max_pixels=input_max_pixels) for p in args.image]
         w, h = _resolve_output_size(
             images,
             explicit=cli_explicit_size,
@@ -503,10 +502,7 @@ def main() -> None:
             str(sample_input_max_pixels or "model-default"),
             sample_do_resize,
         )
-        images = [
-            _load_input_image(p, do_resize=sample_do_resize, input_max_pixels=input_max_pixels)
-            for p in paths
-        ]
+        images = [_load_input_image(p, do_resize=sample_do_resize, input_max_pixels=input_max_pixels) for p in paths]
         w, h = _resolve_output_size(
             images,
             explicit=_explicit_size_from_sample(sample) or cli_explicit_size,

--- a/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
+++ b/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
@@ -1304,7 +1304,10 @@ class NEOChatModel(PreTrainedModel):
         image_token_count = prompt.count('<image>')
         assert len(images) >= image_token_count
         if len(images) > image_token_count:
-            prompt = "<image>\n" * (len(images) - image_token_count) + prompt
+            if image_token_count == 0 and len(images) > 1:
+                prompt = "".join(f"Image-{i + 1}:<image>\n" for i in range(len(images))) + prompt
+            else:
+                prompt = "<image>\n" * (len(images) - image_token_count) + prompt
 
         pixel_values = []
         grid_hw = []

--- a/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
+++ b/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
@@ -1423,6 +1423,17 @@ class NEOChatModel(PreTrainedModel):
                 input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix
             )
 
+        device = hidden_states_condition.device
+        dtype = hidden_states_condition.dtype
+
+        del pixel_values, grid_hw
+        del input_embeds_condition, indexes_condition, attention_mask_condition_prefix
+        if input_embeds_img_condition is not None:
+            del input_embeds_img_condition, indexes_img_condition, attention_mask_img_condition_prefix
+        if input_embeds_uncondition is not None:
+            del input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix
+        del hidden_states_condition
+
         for layer_idx in range(len(past_key_values_condition.layers)):
             past_key_values_condition.layers[layer_idx].keys = past_key_values_condition.layers[layer_idx].keys.expand(
                 batch_size, *past_key_values_condition.layers[layer_idx].keys.shape[1:]
@@ -1462,9 +1473,6 @@ class NEOChatModel(PreTrainedModel):
                 current_len=token_h * token_w,
                 batch_size=batch_size,
             )
-
-        device = hidden_states_condition.device
-        dtype = hidden_states_condition.dtype
 
         grid_h = image_size[1] // self.patch_size
         grid_w = image_size[0] // self.patch_size

--- a/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
+++ b/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
@@ -1329,30 +1329,42 @@ class NEOChatModel(PreTrainedModel):
 
         merge_size = int(1 / self.downsample_ratio)
         question_condition = f"{prompt}"
-        question_img_condition = '<image>' * len(images)
-        question_uncondition = ""
         think_text = ""
+        needs_cfg = not (cfg_scale == 1 and img_cfg_scale == 1)
+        needs_img_condition = needs_cfg and (img_cfg_scale == 1 or cfg_scale != img_cfg_scale)
+        needs_uncondition = needs_cfg and img_cfg_scale != 1
 
         think_content = '<think>\n' if think_mode else '<think>\n\n</think>\n\n' + IMG_START_TOKEN
         query_condition = self._build_t2i_query(question_condition, system_message=SYSTEM_MESSAGE_FOR_GEN, append_text=think_content)
-        query_img_condition = self._build_t2i_query(question_img_condition, append_text=IMG_START_TOKEN)
-        query_uncondition = self._build_t2i_query(question_uncondition, append_text=IMG_START_TOKEN)
+        query_img_condition = (
+            self._build_t2i_query('<image>' * len(images), append_text=IMG_START_TOKEN)
+            if needs_img_condition
+            else None
+        )
+        query_uncondition = self._build_t2i_query("", append_text=IMG_START_TOKEN) if needs_uncondition else None
 
         for i in range(grid_hw.shape[0]):
             num_patch_token = int(grid_hw[i, 0] * grid_hw[i, 1] * self.downsample_ratio**2)
             image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_patch_token + IMG_END_TOKEN
             query_condition = query_condition.replace('<image>', image_tokens, 1)
-            query_img_condition = query_img_condition.replace('<image>', image_tokens, 1)
+            if query_img_condition is not None:
+                query_img_condition = query_img_condition.replace('<image>', image_tokens, 1)
 
         input_embeds_condition, indexes_condition, attention_mask_condition_prefix = self._build_it2i_inputs(
             tokenizer, query_condition, pixel_values, grid_hw
         )
-        input_embeds_img_condition, indexes_img_condition, attention_mask_img_condition_prefix = self._build_it2i_inputs(
-            tokenizer, query_img_condition, pixel_values, grid_hw
-        )
-        input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix = self._build_it2i_inputs(
-            tokenizer, query_uncondition
-        )
+        if query_img_condition is not None:
+            input_embeds_img_condition, indexes_img_condition, attention_mask_img_condition_prefix = self._build_it2i_inputs(
+                tokenizer, query_img_condition, pixel_values, grid_hw
+            )
+        else:
+            input_embeds_img_condition = indexes_img_condition = attention_mask_img_condition_prefix = None
+        if query_uncondition is not None:
+            input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix = self._build_it2i_inputs(
+                tokenizer, query_uncondition
+            )
+        else:
+            input_embeds_uncondition = indexes_uncondition = attention_mask_uncondition_prefix = None
 
         token_h = image_size[1] // (self.patch_size * merge_size)
         token_w = image_size[0] // (self.patch_size * merge_size)
@@ -1360,11 +1372,19 @@ class NEOChatModel(PreTrainedModel):
         indexes_image_condition = self._build_t2i_image_indexes(
             token_h, token_w, indexes_condition[0].max() + 1, device=input_embeds_condition.device
         )
-        indexes_image_img_condition = self._build_t2i_image_indexes(
-            token_h, token_w, indexes_img_condition[0].max() + 1, device=input_embeds_img_condition.device
+        indexes_image_img_condition = (
+            self._build_t2i_image_indexes(
+                token_h, token_w, indexes_img_condition[0].max() + 1, device=input_embeds_img_condition.device
+            )
+            if indexes_img_condition is not None
+            else None
         )
-        indexes_image_uncondition = self._build_t2i_image_indexes(
-            token_h, token_w, indexes_uncondition[0].max() + 1, device=input_embeds_uncondition.device
+        indexes_image_uncondition = (
+            self._build_t2i_image_indexes(
+                token_h, token_w, indexes_uncondition[0].max() + 1, device=input_embeds_uncondition.device
+            )
+            if indexes_uncondition is not None
+            else None
         )
 
         if think_mode:
@@ -1392,12 +1412,16 @@ class NEOChatModel(PreTrainedModel):
             past_key_values_condition, hidden_states_condition = self._it2i_prefix_forward(
                 input_embeds_condition, indexes_condition, attention_mask_condition_prefix
             )
-        past_key_values_img_condition, hidden_states_img_condition = self._it2i_prefix_forward(
-            input_embeds_img_condition, indexes_img_condition, attention_mask_img_condition_prefix
-        )
-        past_key_values_uncondition, hidden_states_uncondition = self._it2i_prefix_forward(
-            input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix
-        )
+        past_key_values_img_condition = None
+        if input_embeds_img_condition is not None:
+            past_key_values_img_condition, _ = self._it2i_prefix_forward(
+                input_embeds_img_condition, indexes_img_condition, attention_mask_img_condition_prefix
+            )
+        past_key_values_uncondition = None
+        if input_embeds_uncondition is not None:
+            past_key_values_uncondition, _ = self._it2i_prefix_forward(
+                input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix
+            )
 
         for layer_idx in range(len(past_key_values_condition.layers)):
             past_key_values_condition.layers[layer_idx].keys = past_key_values_condition.layers[layer_idx].keys.expand(
@@ -1406,34 +1430,38 @@ class NEOChatModel(PreTrainedModel):
             past_key_values_condition.layers[layer_idx].values = past_key_values_condition.layers[layer_idx].values.expand(
                 batch_size, *past_key_values_condition.layers[layer_idx].values.shape[1:]
             )
-            past_key_values_img_condition.layers[layer_idx].keys = past_key_values_img_condition.layers[layer_idx].keys.expand(
-                batch_size, *past_key_values_img_condition.layers[layer_idx].keys.shape[1:]
-            )
-            past_key_values_img_condition.layers[layer_idx].values = past_key_values_img_condition.layers[layer_idx].values.expand(
-                batch_size, *past_key_values_img_condition.layers[layer_idx].values.shape[1:]
-            )
-            past_key_values_uncondition.layers[layer_idx].keys = past_key_values_uncondition.layers[layer_idx].keys.expand(
-                batch_size, *past_key_values_uncondition.layers[layer_idx].keys.shape[1:]
-            )
-            past_key_values_uncondition.layers[layer_idx].values = past_key_values_uncondition.layers[layer_idx].values.expand(
-                batch_size, *past_key_values_uncondition.layers[layer_idx].values.shape[1:]
-            )
+            if past_key_values_img_condition is not None:
+                past_key_values_img_condition.layers[layer_idx].keys = past_key_values_img_condition.layers[layer_idx].keys.expand(
+                    batch_size, *past_key_values_img_condition.layers[layer_idx].keys.shape[1:]
+                )
+                past_key_values_img_condition.layers[layer_idx].values = past_key_values_img_condition.layers[layer_idx].values.expand(
+                    batch_size, *past_key_values_img_condition.layers[layer_idx].values.shape[1:]
+                )
+            if past_key_values_uncondition is not None:
+                past_key_values_uncondition.layers[layer_idx].keys = past_key_values_uncondition.layers[layer_idx].keys.expand(
+                    batch_size, *past_key_values_uncondition.layers[layer_idx].keys.shape[1:]
+                )
+                past_key_values_uncondition.layers[layer_idx].values = past_key_values_uncondition.layers[layer_idx].values.expand(
+                    batch_size, *past_key_values_uncondition.layers[layer_idx].values.shape[1:]
+                )
 
         prepare_flash_kv_cache(
             past_key_values_condition,
             current_len=token_h * token_w,
             batch_size=batch_size,
         )
-        prepare_flash_kv_cache(
-            past_key_values_img_condition,
-            current_len=token_h * token_w,
-            batch_size=batch_size,
-        )
-        prepare_flash_kv_cache(
-            past_key_values_uncondition,
-            current_len=token_h * token_w,
-            batch_size=batch_size,
-        )
+        if past_key_values_img_condition is not None:
+            prepare_flash_kv_cache(
+                past_key_values_img_condition,
+                current_len=token_h * token_w,
+                batch_size=batch_size,
+            )
+        if past_key_values_uncondition is not None:
+            prepare_flash_kv_cache(
+                past_key_values_uncondition,
+                current_len=token_h * token_w,
+                batch_size=batch_size,
+            )
 
         device = hidden_states_condition.device
         dtype = hidden_states_condition.dtype
@@ -1569,8 +1597,10 @@ class NEOChatModel(PreTrainedModel):
             image_prediction = self.unpatchify(z, self.patch_size * merge_size, image_size[1], image_size[0])
 
         clear_flash_kv_cache(past_key_values_condition)
-        clear_flash_kv_cache(past_key_values_img_condition)
-        clear_flash_kv_cache(past_key_values_uncondition)
+        if past_key_values_img_condition is not None:
+            clear_flash_kv_cache(past_key_values_img_condition)
+        if past_key_values_uncondition is not None:
+            clear_flash_kv_cache(past_key_values_uncondition)
 
         self.last_think_content = think_text
         if think_mode:


### PR DESCRIPTION
### Before fix image prefix:
```
<image>
<image>
Prompt
```
<img width="5360" height="2727" alt="before_fix" src="https://github.com/user-attachments/assets/a9b74c9d-6b15-4d71-bad1-3780b90e0fd1" />

### After fixing image prefix (8B-MoT):

```
Image-1:<image>
Image-2:<image>
Prompt
```
<img width="5360" height="2727" alt="after_fix" src="https://github.com/user-attachments/assets/e54c9a6d-dd73-4c96-9eaf-28500f029990" />

For three input images, it will be automatically resized according to the max budget (2x2048x2048). 
Each image is resized to about 1672x1672 (aspect ratio preserved).

<img width="8272" height="2209" alt="3_input_images" src="https://github.com/user-attachments/assets/3e9943d9-0ec4-4449-b71e-7747de0e9527" />

### After fixing image prefix (8B-MoT-8step-preview):

<img width="5360" height="2727" alt="after_fix_8step" src="https://github.com/user-attachments/assets/00d4ab1a-ef92-4bbb-99ca-2ecfe387734f" />
