### PR TITLE
feat(t2i): optimize cache when cfg==1 to reduce max VRAM usage

### DIFF
--- a/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
+++ b/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
@@ -1626,22 +1626,28 @@ class NEOChatModel(PreTrainedModel):
         question_condition = f"{prompt}"
         # question_condition += f"\nThe resolution of the image should be {image_size}"
 
-        question_uncondition = f""
-        # question_uncondition += f"\nThe resolution of the image should be {image_size}"
         think_text = ""
+        needs_cfg = cfg_scale > 1
 
         think_content = '<think>\n' if think_mode else '<think>\n\n</think>\n\n' + IMG_START_TOKEN
         query_condition = self._build_t2i_query(question_condition, system_message=SYSTEM_MESSAGE_FOR_GEN, append_text=think_content)
-        query_uncondition = self._build_t2i_query(question_uncondition, append_text=IMG_START_TOKEN)
+        query_uncondition = self._build_t2i_query("", append_text=IMG_START_TOKEN) if needs_cfg else None
 
         input_ids_condition, indexes_condition, attention_mask_condition_prefix = self._build_t2i_text_inputs(tokenizer, query_condition)
-        input_ids_uncondition, indexes_uncondition, attention_mask_uncondition_prefix = self._build_t2i_text_inputs(tokenizer, query_uncondition)
+        if query_uncondition is not None:
+            input_ids_uncondition, indexes_uncondition, attention_mask_uncondition_prefix = self._build_t2i_text_inputs(tokenizer, query_uncondition)
+        else:
+            input_ids_uncondition = indexes_uncondition = attention_mask_uncondition_prefix = None
        
         token_h = image_size[1] // (self.patch_size * merge_size)
         token_w = image_size[0] // (self.patch_size * merge_size)
 
         indexes_image_condition = self._build_t2i_image_indexes(token_h, token_w, indexes_condition.shape[1], device=input_ids_condition.device)
-        indexes_image_uncondition = self._build_t2i_image_indexes(token_h, token_w, indexes_uncondition.shape[1], device=input_ids_uncondition.device)
+        indexes_image_uncondition = (
+            self._build_t2i_image_indexes(token_h, token_w, indexes_uncondition.shape[1], device=input_ids_uncondition.device)
+            if indexes_uncondition is not None
+            else None
+        )
 
         if think_mode:
             outputs_condition = self.language_model(
@@ -1666,13 +1672,24 @@ class NEOChatModel(PreTrainedModel):
             )
         else:
             past_key_values_condition, hidden_states_condition = self._t2i_prefix_forward(input_ids_condition, indexes_condition, attention_mask_condition_prefix)
-        past_key_values_uncondition, hidden_states_uncondition = self._t2i_prefix_forward(input_ids_uncondition, indexes_uncondition, attention_mask_uncondition_prefix)
+        past_key_values_uncondition = None
+        if input_ids_uncondition is not None:
+            past_key_values_uncondition, _ = self._t2i_prefix_forward(input_ids_uncondition, indexes_uncondition, attention_mask_uncondition_prefix)
+
+        device = hidden_states_condition.device
+        dtype = hidden_states_condition.dtype
+
+        del input_ids_condition, indexes_condition, attention_mask_condition_prefix
+        if input_ids_uncondition is not None:
+            del input_ids_uncondition, indexes_uncondition, attention_mask_uncondition_prefix
+        del hidden_states_condition
 
         for layer_idx in range(len(past_key_values_condition.layers)):
             past_key_values_condition.layers[layer_idx].keys = past_key_values_condition.layers[layer_idx].keys.expand(batch_size, *past_key_values_condition.layers[layer_idx].keys.shape[1:])
             past_key_values_condition.layers[layer_idx].values = past_key_values_condition.layers[layer_idx].values.expand(batch_size, *past_key_values_condition.layers[layer_idx].values.shape[1:])
-            past_key_values_uncondition.layers[layer_idx].keys = past_key_values_uncondition.layers[layer_idx].keys.expand(batch_size, *past_key_values_uncondition.layers[layer_idx].keys.shape[1:])
-            past_key_values_uncondition.layers[layer_idx].values = past_key_values_uncondition.layers[layer_idx].values.expand(batch_size, *past_key_values_uncondition.layers[layer_idx].values.shape[1:])
+            if past_key_values_uncondition is not None:
+                past_key_values_uncondition.layers[layer_idx].keys = past_key_values_uncondition.layers[layer_idx].keys.expand(batch_size, *past_key_values_uncondition.layers[layer_idx].keys.shape[1:])
+                past_key_values_uncondition.layers[layer_idx].values = past_key_values_uncondition.layers[layer_idx].values.expand(batch_size, *past_key_values_uncondition.layers[layer_idx].values.shape[1:])
 
         # prepare flash cache once
         prepare_flash_kv_cache(
@@ -1680,14 +1697,12 @@ class NEOChatModel(PreTrainedModel):
             current_len=token_h * token_w,
             batch_size=batch_size,
         )
-        prepare_flash_kv_cache(
-            past_key_values_uncondition,
-            current_len=token_h * token_w,
-            batch_size=batch_size,
-        )
-
-        device = hidden_states_condition.device
-        dtype = hidden_states_condition.dtype
+        if past_key_values_uncondition is not None:
+            prepare_flash_kv_cache(
+                past_key_values_uncondition,
+                current_len=token_h * token_w,
+                batch_size=batch_size,
+            )
 
         # init noise image tokens
         grid_h = image_size[1] // self.patch_size
@@ -1763,7 +1778,8 @@ class NEOChatModel(PreTrainedModel):
             image_prediction = self.unpatchify(z, self.patch_size * merge_size, image_size[1], image_size[0])
 
         clear_flash_kv_cache(past_key_values_condition)
-        clear_flash_kv_cache(past_key_values_uncondition)
+        if past_key_values_uncondition is not None:
+            clear_flash_kv_cache(past_key_values_uncondition)
 
         self.last_think_content = think_text
         if think_mode:


### PR DESCRIPTION
Test with the following command:

```
python examples/t2i/inference.py \
  --model_path SenseNova/SenseNova-U1-8B-MoT \
  --prompt "这张信息图的标题是“SenseNova-U1”，采用现代极简科技矩阵风格。整体布局为水平三列网格结构，背景是带有极浅银灰色细密点阵的哑光纯白高级纸张纹理，画面长宽比为16:9。\n\n排版采用严谨的视觉层级：主标题使用粗体无衬线黑体字，正文使用清晰的现代等宽字体。配色方案极其克制，以纯白色为底，深炭黑为主视觉文字和边框，浅石板灰用于背景色块和次要信息区分，图标采用精致的银灰色线框绘制。\n\n在画面正上方居中位置，使用醒目的深炭黑粗体字排布着大标题“SenseNova-U1”。标题正下方是浅石板灰色的等宽字体副标题“新一代端到端统一多模态大模型家族”。\n\n画面主体分为左、中、右三个相等的垂直信息区块，区块之间通过充足的负空间进行物理隔离。\n\n左侧区块的主题是概述。顶部有一个银灰色线框绘制的、由放大镜和齿轮交织的图标，旁边是粗体小标题“Overview”。该区块内从上到下垂直排列着三个要点：第一个要点旁边是一个代表文档与照片重叠的极简图标，紧跟着文字“多模态模型家族，统一文本/图像理解和生成”。向下是由两个相连的同心圆组成的架构图标，配有文字“基于NEO-Unify架构（端到端统一理解和生成）”。最下方是一个带有斜线划掉的眼睛和漏斗形状的图标，明确指示文本“无需视觉编码器(VE)和变分自编码器(VAE)”。\n\n中间区块展示模型矩阵。顶部是一个包含两个分支节点的树状网络图标，旁边是粗体小标题“两个模型规格”。区块内分为上下两个包裹在浅石板灰色极细边框内的卡片。上方的卡片内画着一个代表高密度的实心几何立方体图标，大字标注“SenseNova-U1-8B-MoT”，下方是等宽字体说明“8B MoT 密集主干模型”。下方的卡片内画着一个带有闪电符号的网状发光大脑图标，大字标注“SenseNova-U1-A3B-MoT”，下方是等宽字体说明“A3B MoT 混合专家（MoE）主干模型”。在这两个独立卡片的正下方，左侧放置一个笑脸轮廓图标搭配文字“将在HF等平台公开”，右侧放置一个带有折角的书面报告图标搭配文字“将发布技术报告”。\n\n右侧区块呈现核心优势。顶部是一个代表巅峰的上升阶梯折线图图标，旁边是粗体小标题“Highlights”。该区块内部垂直分布着四个带有浅石板灰底色的长方形色块，每个色块内部左侧对应一个具体的图标，右侧为文字。第一个色块内是一个无缝相连的莫比乌斯环图标，配文“原生统一架构，无VE和VAE”。第二个色块内是一个顶端带有星星的奖杯图标，配文“单一统一模型在理解和生成任务上均达到SOTA性能”。第三个色块内是代表文本行与拍立得照片交替穿插的图标，配文“强大的原生交错推理能力（模型原生生成图像进行推理）”。最后一个色块内是一个被切分出一小块的硬币与详细饼状图结合的图标，配文“能生成复杂信息图表，性价比出色”。" \
  --width 2048 --height 2048 \
  --cfg_scale 1.0 --cfg_norm none --timestep_shift 3.0 --num_steps 8 \
  --output output.png \
  --profile
```

Before this PR, the peak allocated memory is around **35.02GB**
```
================================================================                                        
Profile summary                                                                                         ================================================================                                          
model load          :  126.438 s                                                                      
load peak memory    : allocated 32.77 GiB, reserved 33.10 GiB                                           
generations         : 1 call(s), 1 image(s) total, 8.497 s wall                                         
avg per image       :    8.497 s                                                                      
image tokens        : patch_size=32, avg 4096 tok/image (4096)      
throughput          :   482.06 tok/s                                                                  
generation peak mem : allocated 35.02 GiB, reserved 35.69 GiB                                         ================================================================  
```

After this PR, the peak allocated memory is around **34.35 GB (↓~2%)**
```
================================================================
Profile summary
================================================================
  model load          :  113.462 s
  load peak memory    : allocated 32.77 GiB, reserved 33.10 GiB
  generations         : 1 call(s), 1 image(s) total, 9.049 s wall
  avg per image       :    9.049 s
  image tokens        : patch_size=32, avg 4096 tok/image (4096)
  throughput          :   452.63 tok/s
  generation peak mem : allocated 34.35 GiB, reserved 34.85 GiB
================================================================
```
Theoretically, this PR removes the unused unconditional T2I branch when cfg_scale <= 1. In that no-CFG / distilled-model path, we no longer build the unconditional prompt inputs, run the unconditional prefix forward, or preallocate the unconditional flash KV cache.

For a 2048×2048 generation, the output sequence has 4096 image tokens. The expected memory saving is mainly one unconditional KV cache:

```
num_layers * 2(K/V) * total_len * num_kv_heads * head_dim * 2 bytes
```
For our 8B model (bf16), `num_layers = 42, num_kv_heads = 8, head_dim = 128`, so uncondition KV cache is expected to take:
```
42 * 2 * 4096 * 8 * 128 * 2 bytes = 704,643,072 bytes = 0.65625 GB
```
The theoretical value matches the measured reduction from 35.02 GiB to 34.35 GiB (↓0.67GB).