### PR TITLE
fix(submodules): declare EASI and LightLLM URLs in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,13 @@
 	path = evaluation/understanding/neo-evalscope
 	url = https://github.com/OpenSenseNova/evalscope.git
 	branch = neo
+
+[submodule "evaluation/easi/EASI"]
+	path = evaluation/easi/EASI
+	url = https://github.com/EvolvingLMMs-Lab/EASI.git
+	branch = main
+
+[submodule "evaluation/easi/lightllm-stack/LightLLM"]
+	path = evaluation/easi/lightllm-stack/LightLLM
+	url = https://github.com/ModelTC/LightLLM.git
+	branch = neo_plus_clean


### PR DESCRIPTION
## Summary

- Adds the missing `[submodule "..."]` entries for `evaluation/easi/EASI` and `evaluation/easi/lightllm-stack/LightLLM` in `.gitmodules`.
- The repo's index has three gitlinks (mode 160000) but `.gitmodules` previously only declared one (`evaluation/understanding/neo-evalscope`). That mismatch made every `git submodule update --init --recursive` fatal with:
  ```
  fatal: No url found for submodule path 'evaluation/easi/EASI' in .gitmodules
  ```
- URLs come from `evaluation/easi/README.md` (`EvolvingLMMs-Lab/EASI@main`, `ModelTC/LightLLM@neo_plus_clean`). Both upstream repos are reachable and the index-pinned SHAs (`963971b`, `c99e4b3`) shallow-fetch cleanly from those remotes.

## Why now

Anyone running `git clone --recursive` or `git submodule update --init` against this repo currently fails. The error surfaced through `pip install git+https://github.com/OpenSenseNova/SenseNova-U1` (which pip runs `git submodule update --init --recursive` on internally), blocking ComfyUI Manager installs of the SenseNova-U1 custom node. The ComfyUI node has since switched to a tarball URL to side-step pip's submodule init, but the underlying `.gitmodules` drift is still a real bug for the contributor / dev workflow.

## Test plan

- [ ] `git submodule init` on a fresh clone now registers all three submodules without error.
- [ ] `git config --list | grep ^submodule\\.` shows EASI / LightLLM / neo-evalscope URLs.
- [ ] Optional: `git submodule update --init -- evaluation/easi/EASI` succeeds (downloads ~SHA `963971b`).
- [ ] No-op for anyone already running with submodules disabled.