### PR TITLE
deps: relax numpy from ==2.2.0 to >=1.24,<3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,13 @@ dependencies = [
     "huggingface-hub==0.36.2",
     "safetensors==0.6.2",
     "sentencepiece==0.2.1",
-    "numpy==2.2.0",
+    # NumPy is API-stable across 1.24..2.x for the call sites in sensenova_u1
+    # (np.arange/concatenate/cos/sin/einsum/meshgrid/stack/zeros and dtypes
+    # np.float32/64 — none of the numpy 2 removals like np.float_, np.cast,
+    # np.product are touched). Use a range so downstream consumers (notably
+    # ComfyUI environments shipping numpy 1.26.x) don't hit a dependency
+    # resolver conflict against an exact pin.
+    "numpy>=1.24,<3",
     "pillow==12.0.0",
     "tqdm==4.67.1",
     "packaging==25.0",


### PR DESCRIPTION
## Summary

- Replace exact pin `numpy==2.2.0` with the range `numpy>=1.24,<3`.
- Adds an inline comment explaining the rationale (and what would need to change here if any numpy-2-only API is introduced).

## Why

The strict pin is inherited from the internal training reference env for bit-exact checkpoint reproduction, but in downstream / inference environments it routinely causes dependency-resolver conflicts. 

That's an over-constraint by `sensenova-u1`, not a real ABI need: the package's actual numpy use is small and entirely stable across 1.24..2.x.

## What the code actually uses

Audited every call site in `src/sensenova_u1/` (all live in `models/neo_unify/modeling_fm_modules.py`):

- Functions: `np.arange`, `np.concatenate`, `np.cos`, `np.einsum`, `np.meshgrid`, `np.sin`, `np.stack`, `np.zeros`
- Dtypes: `np.float32`, `np.float64`

None of the numpy 2 removals are touched (`np.float_`, `np.int_`, `np.bool_`, `np.cast`, `np.product`, `np.cumproduct`, `np.alltrue`, `np.sometrue`, `np.asfarray`, `np.PINF`, etc.). The same surface works identically on numpy 1.24+ and 2.x.

## Test plan

- [ ] `pip install -e .` resolves on a Python 3.11 env with numpy 1.26.x already present.
- [ ] `pip install -e .` still works on a fresh env (resolver picks something in `>=1.24,<3`).
- [ ] Inference smoke test on a reference checkpoint (e.g. SenseNova-U1-8B-MoT t2i) still produces output that matches the previous bit-exact reference (sanity, not strictly required — numpy isn't on the hot inference path).
- [ ] ComfyUI Manager install of `ComfyUI-SenseNova-U1` no longer surfaces the numpy conflict line.

## Out of scope

Other tight pins in this file (`pillow==12.0.0`, `huggingface-hub==0.36.2`, `safetensors==0.6.2`, `sentencepiece==0.2.1`, `tqdm==4.67.1`, `packaging==25.0`) are similar low-risk candidates for relaxation. Left alone here — separate PR if desired. `torch` / `torchvision` / `transformers` / `tokenizers` / `accelerate` stay strictly pinned (ABI-sensitive).