### PR TITLE
comfyui: publish to Comfy Registry via mirror sync workflow

### DIFF
--- a/.github/workflows/publish-comfyui.yml
+++ b/.github/workflows/publish-comfyui.yml
@@ -1,0 +1,86 @@
+# Sync apps/comfyui/ to the standalone publish mirror
+# (OpenSenseNova/ComfyUI-SenseNova-U1) and propagate the version tag so that
+# repo's own `publish.yml` uploads to https://registry.comfy.org.
+#
+# Trigger: push a tag of the form `comfyui-vX.Y.Z` on this monorepo, or run
+# manually with `workflow_dispatch` (provide `version` like `v0.1.0`).
+#
+# Required secret: COMFYUI_MIRROR_PUSH_TOKEN
+#   A fine-grained PAT (or classic PAT with `repo` scope) belonging to a user
+#   with push access to OpenSenseNova/ComfyUI-SenseNova-U1. Configure under
+#   Settings → Secrets and variables → Actions on this monorepo.
+name: Publish ComfyUI custom node mirror
+
+on:
+  push:
+    tags:
+      - "comfyui-v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to push to the mirror (e.g. v0.1.0)."
+        required: true
+        type: string
+
+jobs:
+  mirror-and-tag:
+    name: Subtree-split apps/comfyui and push to mirror
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out monorepo (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve mirror tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            mirror_tag="${{ inputs.version }}"
+          else
+            # github.ref_name e.g. comfyui-v0.1.0  →  v0.1.0
+            mirror_tag="${GITHUB_REF_NAME#comfyui-}"
+          fi
+          if [[ ! "$mirror_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Resolved mirror tag '$mirror_tag' does not match v*.*.*" >&2
+            exit 1
+          fi
+          echo "mirror_tag=$mirror_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Sanity-check pyproject version matches tag
+        run: |
+          set -euo pipefail
+          tag="${{ steps.resolve.outputs.mirror_tag }}"   # v0.1.0
+          tag_ver="${tag#v}"                              # 0.1.0
+          pyproj_ver="$(grep -E '^version *= *' apps/comfyui/pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [[ "$tag_ver" != "$pyproj_ver" ]]; then
+            echo "Tag $tag does not match apps/comfyui/pyproject.toml version $pyproj_ver" >&2
+            exit 1
+          fi
+
+      - name: Split apps/comfyui into a standalone branch
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git subtree split --prefix=apps/comfyui -b comfyui-publish
+
+      - name: Push split branch + tag to mirror
+        env:
+          GH_TOKEN: ${{ secrets.COMFYUI_MIRROR_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          mirror_tag="${{ steps.resolve.outputs.mirror_tag }}"
+          mirror_url="https://x-access-token:${GH_TOKEN}@github.com/OpenSenseNova/ComfyUI-SenseNova-U1.git"
+          # actions/checkout@v4 leaves behind a global http.<github>.extraheader
+          # using the monorepo's GITHUB_TOKEN; that header overrides the
+          # credentials in `mirror_url`, so the mirror push gets "Repository
+          # not found". Unset it locally for the mirror push only.
+          git config --local --unset-all "http.https://github.com/.extraheader" 2>/dev/null || true
+          git remote add mirror "$mirror_url"
+          # Force-push: the mirror's main is owned by this workflow.
+          git push --force mirror comfyui-publish:main
+          # Move the tag to the new HEAD on the mirror.
+          git tag -f "$mirror_tag" comfyui-publish
+          git push --force mirror "$mirror_tag"

--- a/apps/comfyui/.github/workflows/publish.yml
+++ b/apps/comfyui/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+# Runs in the published mirror repo (OpenSenseNova/ComfyUI-SenseNova-U1) after
+# the monorepo's `publish-comfyui.yml` pushes a fresh subtree + tag here.
+# It does not run in the SenseNova-U1 monorepo because the trigger tag pattern
+# `v*.*.*` is rewritten from the monorepo's `comfyui-v*.*.*` tags during sync.
+name: Publish to Comfy registry
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  publish-node:
+    name: Publish Custom Node to registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Publish Custom Node
+        uses: Comfy-Org/publish-node-action@v1
+        with:
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/apps/comfyui/LICENSE
+++ b/apps/comfyui/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/comfyui/README.md
+++ b/apps/comfyui/README.md
@@ -2,6 +2,12 @@
 
 ComfyUI custom nodes for SenseNova-U1 API and local inference.
 
+> Source of truth lives in [`OpenSenseNova/SenseNova-U1`](https://github.com/OpenSenseNova/SenseNova-U1)
+> under `apps/comfyui/`. The standalone repo
+> [`OpenSenseNova/ComfyUI-SenseNova-U1`](https://github.com/OpenSenseNova/ComfyUI-SenseNova-U1)
+> is a read-only publish mirror used by Comfy Registry; please open PRs against
+> the monorepo.
+
 > Requires a ComfyUI build that ships the v3 node API (`comfy_api.latest`). The nodes are registered through `comfy_entrypoint()`; older ComfyUI installs that only support the v1 `NODE_CLASS_MAPPINGS` registration will not load them.
 
 ## Nodes
@@ -17,38 +23,44 @@ ComfyUI custom nodes for SenseNova-U1 API and local inference.
 
 ## Install
 
-From the SenseNova-U1 repository:
+### Recommended (end users): ComfyUI Manager / Comfy Registry
+
+Search for **SenseNova-U1** in ComfyUI Manager, or:
+
+```bash
+comfy node install ComfyUI-SenseNova-U1
+```
+
+This pulls the latest published release from https://registry.comfy.org and
+installs the declared dependencies (including the `sensenova-u1` Python package
+needed for local inference) into ComfyUI's Python environment automatically.
+Restart ComfyUI afterwards.
+
+### Developer install (from the SenseNova-U1 monorepo)
+
+If you're hacking on the nodes alongside the model source:
 
 ```bash
 python apps/comfyui/install.py --comfyui /path/to/ComfyUI
+python -m pip install -r apps/comfyui/requirements.txt --no-deps  # skip the git-URL line
+python -m pip install -e .                                        # install sensenova-u1 from src/
 ```
 
-By default this creates:
+`install.py` symlinks (or copies, with `--copy`) `apps/comfyui/` into
+`<ComfyUI>/custom_nodes/ComfyUI-SenseNova-U1`. Restart ComfyUI after installation.
 
-```text
-/path/to/ComfyUI/custom_nodes/ComfyUI-SenseNova-U1 -> /path/to/SenseNova-U1/apps/comfyui
-```
-
-Install the lightweight ComfyUI app dependencies in the Python environment used by ComfyUI:
-
-```bash
-python -m pip install -r apps/comfyui/requirements.txt
-```
-
-For local inference, make sure the SenseNova-U1 runtime dependencies are also installed in the
-same environment. When using this app from the main SenseNova-U1 checkout, the loader can discover
-`src/` automatically. You can override it if needed:
-
-```bash
-python -m pip install -e .
-export SENSENOVA_U1_SRC="/path/to/SenseNova-U1/src"
-```
-
-Restart ComfyUI after installation.
+**Source path auto-discovery is location-bound to the symlink.** In the
+default symlink mode, `local_pipeline.default_source_path()` resolves
+`__file__` through the symlink and uses `<repo>/src/` if it sees the file
+sitting under `apps/comfyui/` — no `SENSENOVA_U1_SRC` needed. If you move,
+rename, or delete the monorepo checkout, the link breaks; re-run
+`install.py` to recreate it. With `--copy`, the files no longer point back
+to the repo, so set `SENSENOVA_U1_SRC=/path/to/SenseNova-U1/src` (or fill
+the loader node's `sensenova_u1_src` input) yourself.
 
 ## Workflows
 
-Example workflows live in `workflows/`. Each links to a screenshot of the loaded graph in `docs/`:
+Example workflows live in `example_workflows/`. Each links to a screenshot of the loaded graph in `docs/`:
 
 | Workflow | Description | Preview |
 | --- | --- | --- |

--- a/apps/comfyui/install.py
+++ b/apps/comfyui/install.py
@@ -10,6 +10,36 @@ from pathlib import Path
 DEFAULT_NODE_NAME = "ComfyUI-SenseNova-U1"
 
 
+def _link_or_junction(source: Path, target: Path) -> str:
+    """Create a directory symlink, falling back to an NTFS junction on Windows.
+
+    Windows blocks `os.symlink` unless the user is an administrator or
+    Developer Mode is enabled (WinError 1314). A directory junction
+    (`mklink /J`) provides the same `Path.resolve()`-followable semantics
+    without any privilege; ComfyUI loads through it and the loader's
+    auto-discovery still finds the monorepo source.
+    """
+    try:
+        os.symlink(source, target, target_is_directory=True)
+        return "Linked"
+    except OSError as exc:
+        if sys.platform != "win32":
+            raise
+        try:
+            subprocess.check_call(
+                ["cmd", "/c", "mklink", "/J", str(target), str(source)],
+                stdout=subprocess.DEVNULL,
+            )
+            return "Junctioned"
+        except (subprocess.CalledProcessError, FileNotFoundError) as junc_exc:
+            raise SystemExit(
+                f"Could not create a symlink at {target}: {exc}\n"
+                f"Falling back to `mklink /J` also failed: {junc_exc}\n"
+                "Re-run with --copy, enable Windows Developer Mode "
+                "(Settings → For Developers), or run this script as Administrator."
+            ) from exc
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Install the SenseNova-U1 ComfyUI app.")
     parser.add_argument(
@@ -65,24 +95,39 @@ def main() -> None:
         shutil.copytree(app_dir, target, ignore=shutil.ignore_patterns("__pycache__"))
         action = "Copied"
     else:
-        os.symlink(app_dir, target, target_is_directory=True)
-        action = "Linked"
+        action = _link_or_junction(app_dir, target)
 
     print(f"{action} SenseNova-U1 ComfyUI app:")
     print(f"  {target} -> {app_dir}")
+
+    if not args.copy:
+        # Default symlink (or Windows junction) mode: local_pipeline.py's
+        # default_source_path() resolves __file__ through the link back to
+        # this monorepo and discovers <repo>/src automatically. No env var
+        # needed for local inference.
+        print(f"\n{action} mode: SENSENOVA_U1_SRC auto-resolves to")
+        print(f"  {repo_dir / 'src'}")
+        print("via local_pipeline.default_source_path(), because the loader")
+        print("file is linked back into this checkout. Moving or renaming")
+        print("the monorepo breaks that link — re-run install.py afterwards.")
+    else:
+        # --copy mode: files live under <ComfyUI>/custom_nodes/, no symlink
+        # to follow, so the user must point SENSENOVA_U1_SRC explicitly.
+        print("\nCopy mode: auto-discovery is disabled (no symlink to follow).")
+        print(f"Set SENSENOVA_U1_SRC={repo_dir / 'src'}")
+        print("in the ComfyUI launch environment, or fill the loader node's")
+        print("`sensenova_u1_src` input.")
 
     if args.install_deps:
         requirements = app_dir / "requirements.txt"
         subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(requirements)])
         print("\nFor local inference, also install the SenseNova-U1 runtime in the ComfyUI Python environment:")
         print(f"  {sys.executable} -m pip install -e {repo_dir}")
-        print(f"  export SENSENOVA_U1_SRC={repo_dir / 'src'}")
         print("  Restart ComfyUI.")
     else:
         print("\nNext steps:")
         print(f"  {sys.executable} -m pip install -r {app_dir / 'requirements.txt'}")
         print(f"  {sys.executable} -m pip install -e {repo_dir}  # for local inference")
-        print(f"  export SENSENOVA_U1_SRC={repo_dir / 'src'}")
         print("  Restart ComfyUI.")
 
 

--- a/apps/comfyui/local_pipeline.py
+++ b/apps/comfyui/local_pipeline.py
@@ -536,12 +536,29 @@ class SenseNovaU1LocalModel:
 
 
 def default_source_path() -> str:
-    env_path = os.environ.get("SENSENOVA_U1_SRC", "")
-    if env_path:
-        return env_path
-    repo_src = Path(__file__).resolve().parents[2] / "src"
-    if repo_src.is_dir():
-        return str(repo_src)
+    """Resolve a `sensenova_u1` source path for the loader's default input.
+
+    Precedence:
+      1. ``SENSENOVA_U1_SRC`` env var (manual override; wins everywhere).
+      2. Monorepo symlink auto-discovery — *location-bound*: only fires when
+         this file resolves to ``<repo>/apps/comfyui/local_pipeline.py``,
+         which happens when ``install.py`` (default mode) symlinks the
+         directory into ``<ComfyUI>/custom_nodes/ComfyUI-SenseNova-U1``.
+         ``--copy`` mode and Registry / Manager installs land somewhere
+         else, so this branch is skipped for them.
+      3. ``DEFAULT_SOURCE_PATH`` (empty) — falls back to the installed
+         ``sensenova_u1`` wheel in the ComfyUI Python environment.
+    """
+    env = os.environ.get("SENSENOVA_U1_SRC", "").strip()
+    if env:
+        return env
+    # Path.resolve() follows symlinks, so the install.py-created link
+    # leads back to the monorepo checkout.
+    here = Path(__file__).resolve()
+    if here.parent.name == "comfyui" and here.parents[1].name == "apps":
+        repo_src = here.parents[2] / "src"
+        if repo_src.is_dir():
+            return str(repo_src)
     return DEFAULT_SOURCE_PATH
 
 
@@ -695,9 +712,11 @@ def _import_sensenova_u1():
         from sensenova_u1.utils import load_model_and_tokenizer
     except ImportError as exc:
         raise RuntimeError(
-            "Local SenseNova-U1 inference requires the sensenova_u1 package. "
-            "Install this repository into the ComfyUI Python environment, set "
-            "SENSENOVA_U1_SRC, or fill the loader's sensenova_u1_src input."
+            "Local SenseNova-U1 inference requires the `sensenova_u1` package. "
+            "Install it into the ComfyUI Python environment, e.g.:\n"
+            "  pip install 'sensenova-u1 @ git+https://github.com/OpenSenseNova/SenseNova-U1'\n"
+            "Or, for monorepo development, set SENSENOVA_U1_SRC=/path/to/SenseNova-U1/src "
+            "(or fill the loader's `sensenova_u1_src` input)."
         ) from exc
     return sensenova_u1, load_model_and_tokenizer, smart_resize
 

--- a/apps/comfyui/pyproject.toml
+++ b/apps/comfyui/pyproject.toml
@@ -1,0 +1,40 @@
+# Metadata read by `Comfy-Org/publish-node-action` when this directory is
+# published to https://registry.comfy.org as the standalone repository
+# `OpenSenseNova/ComfyUI-SenseNova-U1`. The SenseNova-U1 monorepo's build
+# (hatchling) ignores this file — see ../../pyproject.toml.
+#
+# Intentionally minimal: no [tool.ruff] / [tool.pytest] / [build-system]
+# sections, so the monorepo's root configuration continues to apply to files
+# under this directory.
+[project]
+name = "ComfyUI-SenseNova-U1"
+version = "0.1.4"
+description = "SenseNova-U1 custom nodes for ComfyUI (API + local inference)."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+authors = [{ name = "OpenSenseNova" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "httpx",
+    "numpy",
+    "pillow",
+    "python-dotenv",
+    # Tarball URL (not git+https) so pip skips submodule init; see
+    # requirements.txt for the full rationale. Bump to /tags/vX.Y.Z.tar.gz
+    # before each official Comfy Registry publish for reproducibility.
+    "sensenova-u1 @ https://github.com/OpenSenseNova/SenseNova-U1/archive/refs/heads/main.tar.gz",
+]
+
+[project.urls]
+Homepage = "https://github.com/OpenSenseNova/ComfyUI-SenseNova-U1"
+Repository = "https://github.com/OpenSenseNova/ComfyUI-SenseNova-U1"
+Source = "https://github.com/OpenSenseNova/SenseNova-U1/tree/main/apps/comfyui"
+
+[tool.comfy]
+PublisherId = "sensenova"
+DisplayName = "ComfyUI-SenseNova-U1"
+Icon = ""

--- a/apps/comfyui/requirements.txt
+++ b/apps/comfyui/requirements.txt
@@ -2,3 +2,10 @@ httpx
 numpy
 pillow
 python-dotenv
+# Local inference path. Use a GitHub-generated tarball, not git+https, so pip
+# doesn't run `git submodule update --init --recursive` — that pulls
+# evaluation/easi/* (hundreds of MB of benchmarking subrepos) which ComfyUI
+# users never need. GitHub's archive tarball already strips submodule trees.
+# Monorepo developers can `pip install -e .` from the repo root instead and
+# skip this line via `pip install -r requirements.txt --no-deps`.
+sensenova-u1 @ https://github.com/OpenSenseNova/SenseNova-U1/archive/refs/heads/main.tar.gz


### PR DESCRIPTION
## Summary

Wires `apps/comfyui/` up so it can be released to https://registry.comfy.org as **ComfyUI-SenseNova-U1** while keeping this monorepo as the source of truth.

Tagging `comfyui-vX.Y.Z` on this repo triggers a new workflow that `git subtree split`s `apps/comfyui/` into the standalone [`OpenSenseNova/ComfyUI-SenseNova-U1`](https://github.com/OpenSenseNova/ComfyUI-SenseNova-U1) mirror and force-pushes a fresh `main` + `vX.Y.Z` tag. The mirror's own `publish.yml` then invokes `Comfy-Org/publish-node-action@v1` to upload to Comfy Registry.

## Files

### `apps/comfyui/`

- **`pyproject.toml`** (new): minimal `[project]` + `[tool.comfy]` (PublisherId / DisplayName). No `[tool.ruff] / [tool.pytest] / [build-system]` so hatch/uv/ruff continue to read the root monorepo configuration.
- **`requirements.txt`**: declare `sensenova-u1` as a GitHub *tarball* URL (not `git+https`) so pip skips `git submodule update --init --recursive` — that would pull `evaluation/easi/*` (hundreds of MB of benchmarking subrepos) which ComfyUI users never need. The tarball already strips submodule trees.
- **`LICENSE`** (new): copied alongside the published tree.
- **`README.md`**: mirror note at the top; install section split into *Comfy Manager (end users)* and *Developer install (monorepo)*; documents that source-path auto-discovery is bound to the symlink location; fixes the `example_workflows/` directory name typo.
- **`local_pipeline.py`**: `default_source_path()` resolves a `sensenova_u1` checkout in this order — `SENSENOVA_U1_SRC` env var > monorepo symlink auto-discovery (only when `__file__` resolves under `apps/comfyui/`) > empty (fall back to installed wheel). Sharper `ImportError` message pointing at the tarball install command.
- **`install.py`**: factor out `_link_or_junction()`; on Windows the symlink attempt falls back to an NTFS junction via `mklink /J` so it works without Administrator / Developer Mode. Post-install message reports link / junction / copy mode and notes that moving the monorepo breaks the link-based auto-discovery.
- **`.github/workflows/publish.yml`** (new): runs in the mirror repo after sync; triggered by `v*.*.*` tags; explicitly grants `contents: read` because naming any `permissions:` block drops everything else to none.

### `.github/workflows/`

- **`publish-comfyui.yml`** (new): triggered by `comfyui-vX.Y.Z` tag push (or manual dispatch). Sanity-checks `pyproject.toml` version against the tag, runs `git subtree split --prefix=apps/comfyui`, then force-pushes the split branch + tag to `OpenSenseNova/ComfyUI-SenseNova-U1`. Uses `COMFYUI_MIRROR_PUSH_TOKEN` (fine-grained PAT with Contents + Workflows R/W on the mirror). Locally unsets the `http.<github>.extraheader` that `actions/checkout@v4` installs; otherwise the inherited monorepo `GITHUB_TOKEN` overrides the URL-embedded PAT and the push fails with "Repository not found".

## End-to-end validation

Iteratively tested through Comfy Registry:

| Tag | What it validated |
| --- | --- |
| `comfyui-v0.1.0` | publisher = `gaclove`, then re-cut as `sensenova` once that publisher was created |
| `comfyui-v0.1.1` | full subtree split → mirror push → Registry publish path |
| `comfyui-v0.1.2` | switch from `git+https://` to tarball URL — Comfy Manager install no longer trips `git submodule update --init --recursive` on the missing `.gitmodules` entries for EASI / LightLLM |
| `comfyui-v0.1.3` | sensenova-u1 numpy pin relaxed (validated with a temp tarball URL pointing at #185's branch — already reverted in this PR; pyproject is at `0.1.4` so the next tag is clean) |

Current Registry state:

```
0.1.3 - Pending (validation; temp tarball URL → fix/relax-numpy-pin)
0.1.2 - Pending
0.1.1 - Pending
0.1.0 - Flagged (numpy pin conflict)
```

## Coordination notes

- **PR #184** (.gitmodules fix) is not a hard blocker for ComfyUI installs anymore — the tarball URL side-steps submodule init entirely — but it remains a real bug for `git clone --recursive` users.
- **PR #185** (relax `numpy==2.2.0` to `>=1.24,<3`) **should be merged before** cutting the next official tag here, since this branch's tarball URL is `refs/heads/main`. After #185 merges, anyone tagging `comfyui-v0.1.4` from here will publish a Registry version that no longer fights with ComfyUI environments shipping numpy 1.26.x.

## How to cut the next release after this PR merges

```bash
# pyproject already says 0.1.4
git tag comfyui-v0.1.4
git push origin comfyui-v0.1.4
# Watch Actions on this repo, then on the mirror, then https://registry.comfy.org
```

## Test plan

- [ ] CI for this PR passes (no new workflow is auto-triggered by the PR itself — `publish-comfyui.yml` only fires on `comfyui-v*.*.*` tags).
- [ ] After merge + tag `comfyui-v0.1.4`:
  - [ ] `Publish ComfyUI custom node mirror` completes successfully on this repo.
  - [ ] `Publish to Comfy registry` completes successfully on the mirror.
  - [ ] `https://api.comfy.org/nodes/ComfyUI-SenseNova-U1/versions` lists `0.1.4` with `sensenova-u1 @ https://github.com/.../archive/refs/heads/main.tar.gz`.
  - [ ] Fresh ComfyUI Manager install of `ComfyUI-SenseNova-U1` no longer surfaces the `numpy==2.2.0` conflict line, and the `git submodule update` error is gone.