### PR TITLE
feat: support Intel XPU alongside CUDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ outputs/
 wandb/
 logs/
 output.png
+.gitnexus
+.claude/
+CLAUDE.md
+AGENTS.md
+.codex

--- a/apps/comfyui/local_pipeline.py
+++ b/apps/comfyui/local_pipeline.py
@@ -535,6 +535,24 @@ class SenseNovaU1LocalModel:
         )
 
 
+def default_device() -> str:
+    """Best-available accelerator string for the ComfyUI loader's default UI value.
+
+    Resolved at node-registration time. Prefers CUDA > XPU > CPU; ``torch``
+    is imported lazily so this module stays importable in tooling that
+    doesn't have torch installed.
+    """
+    try:
+        import torch
+    except ImportError:
+        return "cuda"
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.xpu.is_available():
+        return "xpu"
+    return "cpu"
+
+
 def default_source_path() -> str:
     """Resolve a `sensenova_u1` source path for the loader's default input.
 

--- a/apps/comfyui/nodes.py
+++ b/apps/comfyui/nodes.py
@@ -38,6 +38,7 @@ try:
         T2I_RESOLUTION_OPTIONS,
         VRAM_MODE_OPTIONS,
         SenseNovaU1LocalModel,
+        default_device,
         default_source_path,
         interleave_output_to_tuple,
         interleave_result_to_markdown,
@@ -74,6 +75,7 @@ except ImportError:  # pragma: no cover - supports direct imports during tests
         T2I_RESOLUTION_OPTIONS,
         VRAM_MODE_OPTIONS,
         SenseNovaU1LocalModel,
+        default_device,
         default_source_path,
         interleave_output_to_tuple,
         interleave_result_to_markdown,
@@ -466,7 +468,11 @@ class SenseNovaU1LocalLoader(io.ComfyNode):
                     default=default_source_path(),
                     tooltip="Optional SenseNova-U1 source checkout or src directory.",
                 ),
-                io.String.Input("device", default="cuda"),
+                io.String.Input(
+                    "device",
+                    default=default_device(),
+                    tooltip="Compute device, e.g. 'cuda', 'cuda:0', 'xpu', 'xpu:0', 'cpu'. Defaults to the best available accelerator.",
+                ),
                 io.Combo.Input("dtype", options=list(DTYPE_OPTIONS), default="bfloat16"),
                 io.Combo.Input("attn_backend", options=list(ATTN_BACKEND_OPTIONS), default="auto"),
                 io.Combo.Input(

--- a/examples/editing/inference.py
+++ b/examples/editing/inference.py
@@ -17,6 +17,7 @@ from sensenova_u1.utils import (
     DEFAULT_VRAM_MODE,
     InferenceProfiler,
     add_offload_args,
+    best_available_device,
     load_and_merge_lora_weight_from_safetensors,
     load_model_and_tokenizer,
     make_offload_ctx,
@@ -383,7 +384,11 @@ def parse_args() -> argparse.Namespace:
         ),
     )
 
-    p.add_argument("--device", default="cuda")
+    p.add_argument(
+        "--device",
+        default=str(best_available_device()),
+        help="Compute device, e.g. 'cuda', 'cuda:0', 'xpu', 'xpu:0', 'cpu'. Defaults to the best available accelerator.",
+    )
     p.add_argument(
         "--dtype",
         default="bfloat16",

--- a/examples/interleave/inference.py
+++ b/examples/interleave/inference.py
@@ -17,9 +17,11 @@ from sensenova_u1.utils import (
     DEFAULT_VRAM_MODE,
     InferenceProfiler,
     add_offload_args,
+    best_available_device,
     load_and_merge_lora_weight_from_safetensors,
     load_model_and_tokenizer,
     make_offload_ctx,
+    seed_all_accelerators,
     vram_mode_to_prefetch_count,
 )
 
@@ -62,12 +64,11 @@ DEFAULT_SYSTEM_MESSAGE = """You are a multimodal assistant capable of reasoning 
 
 
 def _set_seed(seed: int) -> None:
-    """Make sampling reproducible across python / numpy / torch (+ all CUDA devices)."""
+    """Make sampling reproducible across python / numpy / torch (+ every available accelerator backend)."""
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(seed)
+    seed_all_accelerators(seed)
 
 
 def _round_by(n: int, factor: int) -> int:
@@ -378,7 +379,11 @@ def parse_args() -> argparse.Namespace:
         ),
     )
 
-    p.add_argument("--device", default="cuda")
+    p.add_argument(
+        "--device",
+        default=str(best_available_device()),
+        help="Compute device, e.g. 'cuda', 'cuda:0', 'xpu', 'xpu:0', 'cpu'. Defaults to the best available accelerator.",
+    )
     p.add_argument(
         "--dtype",
         default="bfloat16",

--- a/examples/t2i/inference.py
+++ b/examples/t2i/inference.py
@@ -15,6 +15,7 @@ from sensenova_u1.utils import (
     DEFAULT_VRAM_MODE,
     InferenceProfiler,
     add_offload_args,
+    best_available_device,
     load_and_merge_lora_weight_from_safetensors,
     load_model_and_tokenizer,
     make_offload_ctx,
@@ -243,7 +244,11 @@ def parse_args() -> argparse.Namespace:
         ),
     )
 
-    p.add_argument("--device", default="cuda")
+    p.add_argument(
+        "--device",
+        default=str(best_available_device()),
+        help="Compute device, e.g. 'cuda', 'cuda:0', 'xpu', 'xpu:0', 'cpu'. Defaults to the best available accelerator.",
+    )
     p.add_argument(
         "--dtype",
         default="bfloat16",

--- a/examples/vqa/inference.py
+++ b/examples/vqa/inference.py
@@ -14,6 +14,7 @@ from sensenova_u1.utils import (
     DEFAULT_VRAM_MODE,
     InferenceProfiler,
     add_offload_args,
+    best_available_device,
     infer_input_device,
     load_model_and_tokenizer,
     make_offload_ctx,
@@ -116,7 +117,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--top_k", type=int, default=None, help="Top-k sampling (default: None).")
     p.add_argument("--repetition_penalty", type=float, default=None, help="Repetition penalty (default: None).")
 
-    p.add_argument("--device", default="cuda")
+    p.add_argument(
+        "--device",
+        default=str(best_available_device()),
+        help="Compute device, e.g. 'cuda', 'cuda:0', 'xpu', 'xpu:0', 'cpu'. Defaults to the best available accelerator.",
+    )
     p.add_argument(
         "--dtype",
         default="bfloat16",

--- a/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
+++ b/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
@@ -92,18 +92,27 @@ def clear_flash_kv_cache(past_key_values):
         if hasattr(layer, "flash_v_cache"):
             delattr(layer, "flash_v_cache")
 
-@torch.cuda.amp.autocast(dtype=torch.float32)
 def optimized_scale(positive_flat, negative_flat):
+    # Force the divisor computation to float32 regardless of the surrounding
+    # autocast (the squared-norm/division is what we don't want in fp16/bf16).
+    # ``device_type`` is taken from the input so this runs equally on CUDA and
+    # XPU; ``mps`` is rerouted to ``cpu`` because torch.autocast rejects it.
+    device_type = positive_flat.device.type
+    if device_type == "mps":
+        device_type = "cpu"
+    with torch.autocast(device_type=device_type, enabled=False):
+        positive_flat = positive_flat.float()
+        negative_flat = negative_flat.float()
 
-    # Calculate dot production
-    dot_product = torch.sum(positive_flat * negative_flat, dim=1, keepdim=True)
+        # Calculate dot production
+        dot_product = torch.sum(positive_flat * negative_flat, dim=1, keepdim=True)
 
-    # Squared norm of uncondition
-    squared_norm = torch.sum(negative_flat ** 2, dim=1, keepdim=True) + 1e-8
+        # Squared norm of uncondition
+        squared_norm = torch.sum(negative_flat ** 2, dim=1, keepdim=True) + 1e-8
 
-    # st_star = v_cond^T * v_uncond / ||v_uncond||^2
-    st_star = dot_product / squared_norm
-    
+        # st_star = v_cond^T * v_uncond / ||v_uncond||^2
+        st_star = dot_product / squared_norm
+
     return st_star
 
 def build_abs_positions_from_grid_hw(grid_hw: torch.Tensor, device=None):

--- a/src/sensenova_u1/models/neo_unify/modeling_qwen3.py
+++ b/src/sensenova_u1/models/neo_unify/modeling_qwen3.py
@@ -144,7 +144,11 @@ def _sdpa_attn_func(q, k, v, dropout_p: float = 0.0, softmax_scale=None, causal:
 
 def _flash_or_sdpa(q, k, v, dropout_p: float = 0.0, softmax_scale=None, causal: bool = False):
     backend = effective_attn_backend()
-    if backend == "flash":
+    # flash-attn ships CUDA kernels only. On XPU / CPU we transparently fall
+    # back to SDPA even if the user asked for ``flash`` — the alternative
+    # (crashing on first forward) is worse, and ``set_attn_backend('flash')``
+    # already guarded against the "package missing" case.
+    if backend == "flash" and q.device.type == "cuda":
         return flash_attn_func(q, k, v, dropout_p=dropout_p, softmax_scale=softmax_scale, causal=causal)
     return _sdpa_attn_func(q, k, v, dropout_p=dropout_p, softmax_scale=softmax_scale, causal=causal)
 

--- a/src/sensenova_u1/utils/__init__.py
+++ b/src/sensenova_u1/utils/__init__.py
@@ -1,3 +1,9 @@
+from .accel import (
+    best_available_device,
+)
+from .accel import (
+    manual_seed_all as seed_all_accelerators,
+)
 from .checkpoint_loading import (
     add_offload_args,
     infer_input_device,
@@ -32,6 +38,7 @@ __all__ = [
     "ModelParamInspector",
     "VRAM_MODE_OPTIONS",
     "add_offload_args",
+    "best_available_device",
     "build_rules",
     "format_bytes",
     "format_param_count",
@@ -45,6 +52,7 @@ __all__ = [
     "offload_layers_sync",
     "parse_max_memory",
     "save_compare",
+    "seed_all_accelerators",
     "set_gguf2meta_model",
     "vram_mode_to_prefetch_count",
 ]

--- a/src/sensenova_u1/utils/accel.py
+++ b/src/sensenova_u1/utils/accel.py
@@ -1,0 +1,91 @@
+"""Accelerator-agnostic helpers for CUDA / XPU.
+
+The codebase used to hard-code ``torch.cuda.*`` for device-availability checks,
+cache management, and stream APIs. This module centralises the small amount of
+namespace switching needed so the same code paths work on both CUDA (incl.
+ROCm via the ``cuda`` namespace) and Intel XPU.
+
+CPU / MPS are intentionally out of scope: the layer-offload / inference path
+needs pinned host memory and dedicated transfer streams, which neither of
+those backends exposes uniformly. Targets PyTorch >= 2.5 where ``torch.xpu``
+is in-tree.
+"""
+
+from __future__ import annotations
+
+import torch
+
+SUPPORTED_DEVICE_TYPES: tuple[str, ...] = ("cuda", "xpu")
+
+
+def accel_module(device: torch.device):
+    """Return ``torch.cuda`` or ``torch.xpu`` matching ``device.type``."""
+    if device.type == "cuda":
+        return torch.cuda
+    if device.type == "xpu":
+        return torch.xpu
+    raise NotImplementedError(f"No accelerator namespace for device {device!r}; supported: {SUPPORTED_DEVICE_TYPES}.")
+
+
+def require_accelerator(device: torch.device) -> None:
+    """Raise unless ``device`` is a backend the inference path actually supports."""
+    if device.type not in SUPPORTED_DEVICE_TYPES:
+        raise NotImplementedError(
+            f"Inference requires a CUDA or XPU device (got {device!r}). "
+            "CPU / MPS lack the pinned-memory and stream primitives used here."
+        )
+
+
+def is_available(device_type: str) -> bool:
+    """``True`` if the backend module reports an available device."""
+    if device_type == "cuda":
+        return torch.cuda.is_available()
+    if device_type == "xpu":
+        return torch.xpu.is_available()
+    return False
+
+
+def best_available_device() -> torch.device:
+    """Pick the best available accelerator, preferring CUDA over XPU over CPU."""
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.xpu.is_available():
+        return torch.device("xpu")
+    return torch.device("cpu")
+
+
+def empty_cache(device: torch.device | None = None) -> None:
+    """Release the accelerator's caching-allocator blocks.
+
+    With ``device=None`` runs the equivalent of "for every backend that has a
+    device available, drop its cache" — used at teardown where we just want
+    the global state cleaned up regardless of which backend we ran on.
+    """
+    if device is None:
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        if torch.xpu.is_available():
+            torch.xpu.empty_cache()
+        return
+    if device.type in SUPPORTED_DEVICE_TYPES and is_available(device.type):
+        accel_module(device).empty_cache()
+
+
+def synchronize(device: torch.device | None = None) -> None:
+    """Block until pending work on the accelerator completes."""
+    if device is None:
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        if torch.xpu.is_available():
+            torch.xpu.synchronize()
+        return
+    if device.type in SUPPORTED_DEVICE_TYPES and is_available(device.type):
+        accel_module(device).synchronize(device)
+
+
+def manual_seed_all(seed: int) -> None:
+    """Seed all available accelerator devices (CUDA + XPU)."""
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    if torch.xpu.is_available():
+        torch.xpu.manual_seed_all(seed)

--- a/src/sensenova_u1/utils/checkpoint_loading.py
+++ b/src/sensenova_u1/utils/checkpoint_loading.py
@@ -11,14 +11,14 @@ Usage:
     model, tokenizer = load_model_and_tokenizer(
         model_path="sensenova/SenseNova-U1-8B-MoT",
         dtype=torch.bfloat16,
-        device="cuda",
+        # device=None auto-picks CUDA > XPU > CPU. Pass an explicit
+        # "cuda" / "cuda:0" / "xpu" / "xpu:0" to override.
     )
 
     # GGUF override (config / tokenizer still come from `model_path`):
     model, tokenizer = load_model_and_tokenizer(
         model_path="sensenova/SenseNova-U1-8B-MoT",
         dtype=torch.bfloat16,
-        device="cuda",
         gguf_checkpoint="/path/to/SenseNova-U1-8B-MoT-Q5_K_M.gguf",
     )
 """
@@ -35,7 +35,14 @@ from typing import Any
 import torch
 from torch import nn
 
+from . import accel
+
 LOGGER = logging.getLogger(__name__)
+
+
+def _default_device() -> torch.device:
+    """Pick CUDA, then XPU, then CPU. Used as the default ``device`` for loaders."""
+    return accel.best_available_device()
 
 
 def add_offload_args(parser: argparse.ArgumentParser) -> None:
@@ -74,12 +81,18 @@ def add_offload_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def infer_input_device(model: nn.Module, fallback: str | torch.device = "cuda") -> torch.device:
-    """Pick a usable device for tensors passed into a dispatched model."""
+def infer_input_device(model: nn.Module, fallback: str | torch.device | None = None) -> torch.device:
+    """Pick a usable device for tensors passed into a dispatched model.
+
+    When ``fallback`` is ``None`` (the default), auto-detects the best
+    accelerator (CUDA > XPU > CPU).
+    """
     for param in model.parameters():
         if param.device.type not in {"cpu", "meta"}:
             return param.device
-    return torch.device(fallback)
+    if fallback is None:
+        return _default_device()
+    return torch.device(fallback) if isinstance(fallback, str) else fallback
 
 
 def _resolve_local_model_path(model_path: str) -> str:
@@ -103,7 +116,7 @@ def load_model_and_tokenizer(
     model_path: str,
     *,
     dtype: torch.dtype,
-    device: str | torch.device | None = "cuda",
+    device: str | torch.device | None = None,
     gguf_checkpoint: str | None = None,
     device_map: str | None = None,
     max_memory: str | dict[int | str, str] | None = None,
@@ -139,6 +152,9 @@ def load_model_and_tokenizer(
             device_map,
         )
         device_map = None
+
+    if device is None and not device_map and not for_offload:
+        device = _default_device()
 
     model_path = _resolve_local_model_path(model_path)
     config = AutoConfig.from_pretrained(model_path)
@@ -235,6 +251,5 @@ def _load_from_gguf(
 
     del state_dict
     gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    accel.empty_cache()
     return model.eval()

--- a/src/sensenova_u1/utils/layer_offload.py
+++ b/src/sensenova_u1/utils/layer_offload.py
@@ -1,7 +1,8 @@
 """Layer offload wrapper for memory-efficient inference.
 
 Keeps each layer of an ``nn.ModuleList`` in CPU pinned memory and moves it
-onto a CUDA device on demand. Two modes share a single :class:`LayerOffloadWrapper`:
+onto an accelerator device (CUDA or XPU) on demand. Two modes share a single
+:class:`LayerOffloadWrapper`:
 
 - ``prefetch_count == 0`` — synchronous: load before forward, evict after.
 - ``prefetch_count >= 1`` — asynchronous: a dedicated CUDA stream prefetches
@@ -41,6 +42,9 @@ from typing import Any
 import torch
 from torch import nn
 
+from .accel import accel_module as _accel
+from .accel import require_accelerator as _require_accelerator
+
 logger = logging.getLogger(__name__)
 
 
@@ -50,11 +54,12 @@ def _log_vram(label: str, target_device: torch.device, *, reset_peak: bool = Fal
     without explicit DEBUG opt-in.
     """
     try:
-        if target_device.type != "cuda" or not torch.cuda.is_available():
+        accel = _accel(target_device)
+        if not accel.is_available():
             return
-        alloc = torch.cuda.memory_allocated(target_device) / (1024**3)
-        reserved = torch.cuda.memory_reserved(target_device) / (1024**3)
-        peak = torch.cuda.max_memory_allocated(target_device) / (1024**3)
+        alloc = accel.memory_allocated(target_device) / (1024**3)
+        reserved = accel.memory_reserved(target_device) / (1024**3)
+        peak = accel.max_memory_allocated(target_device) / (1024**3)
         logger.info(
             "[layer_offload vram] %-40s | alloc=%6.2f GiB  reserved=%6.2f GiB  peak=%6.2f GiB",
             label,
@@ -63,7 +68,7 @@ def _log_vram(label: str, target_device: torch.device, *, reset_peak: bool = Fal
             peak,
         )
         if reset_peak:
-            torch.cuda.reset_peak_memory_stats(target_device)
+            accel.reset_peak_memory_stats(target_device)
     except Exception as exc:  # pragma: no cover - diagnostic only
         logger.debug("vram log %r failed: %s", label, exc)
 
@@ -76,23 +81,6 @@ def _resolve_attr(module: nn.Module, dotted_path: str) -> nn.ModuleList:
     if not isinstance(obj, nn.ModuleList):
         raise TypeError(f"Expected nn.ModuleList at '{dotted_path}', got {type(obj).__name__}")
     return obj
-
-
-def _require_cuda(target_device: torch.device) -> None:
-    """Reject non-CUDA target devices with a clear error.
-
-    Pinned memory, dedicated streams, and ``record_stream`` are CUDA-only
-    APIs in PyTorch; ROCm reuses the ``cuda`` namespace, so it works, but
-    MPS / XPU / CPU do not. Failing fast here is more honest than letting
-    the wrapper appear to accept any device when ``target_device`` is in
-    fact a façade.
-    """
-    if target_device.type != "cuda":
-        raise NotImplementedError(
-            f"Layer offload requires a CUDA target_device (got {target_device!r}). "
-            "Pinned memory and prefetch streams are CUDA-specific; MPS / XPU / CPU "
-            "are not supported."
-        )
 
 
 def _is_cuda_malloc_async_backend() -> bool:
@@ -152,13 +140,17 @@ class _LayerStore:
         self.target_device = target_device
         self.num_layers = len(layers)
 
+        # ``Tensor.pin_memory()`` defaults to CUDA; XPU needs an explicit
+        # device kind so the host buffer is registered with the right driver.
+        self._pin_device = target_device.type
+
         self._pinned: list[dict[str, torch.Tensor]] = []
         self._on_gpu: set[int] = set()
 
         for layer in layers:
             pinned: dict[str, torch.Tensor] = {}
             for name, tensor in itertools.chain(layer.named_parameters(), layer.named_buffers()):
-                pinned_tensor = tensor.data.pin_memory()
+                pinned_tensor = tensor.data.pin_memory(device=self._pin_device)
                 tensor.data = pinned_tensor
                 pinned[name] = pinned_tensor
             self._pinned.append(pinned)
@@ -217,16 +209,17 @@ class _AsyncPrefetcher:
     def __init__(self, store: _LayerStore, layers: nn.ModuleList) -> None:
         self._store = store
         self._layers = layers
-        self._stream = torch.cuda.Stream(device=store.target_device)
-        self._events: dict[int, torch.cuda.Event] = {}
+        self._accel = _accel(store.target_device)
+        self._stream = self._accel.Stream(device=store.target_device)
+        self._events: dict[int, Any] = {}
 
     def prefetch(self, idx: int) -> None:
         """Begin async transfer of layer *idx* to GPU (no-op if already there)."""
         if self._store.is_on_gpu(idx) or idx in self._events:
             return
-        with torch.cuda.stream(self._stream):
+        with self._accel.stream(self._stream):
             self._store.move_to_gpu(idx, self._layers[idx], non_blocking=True)
-            event = torch.cuda.Event()
+            event = self._accel.Event()
             event.record(self._stream)
             self._events[idx] = event
 
@@ -234,14 +227,15 @@ class _AsyncPrefetcher:
         """Block the compute stream until layer *idx*'s transfer completes."""
         event = self._events.pop(idx, None)
         if event is not None:
-            torch.cuda.current_stream(self._store.target_device).wait_event(event)
+            self._accel.current_stream(self._store.target_device).wait_event(event)
 
     def cleanup(self) -> None:
-        """Drain pending work and release CUDA stream/event resources."""
+        """Drain pending work and release accelerator stream/event resources."""
         self._events.clear()
         self._stream = None
         self._layers = None
         self._store = None
+        self._accel = None
 
 
 class LayerOffloadWrapper(nn.Module):
@@ -261,7 +255,8 @@ class LayerOffloadWrapper(nn.Module):
         Dotted attribute path to the ``nn.ModuleList`` of sequential layers
         (e.g. ``"transformer_blocks"`` or ``"language_model.model.layers"``).
     target_device:
-        The CUDA device to use for compute. MPS / XPU / CPU are rejected.
+        The accelerator device to use for compute (CUDA or XPU). CPU / MPS
+        are rejected.
     prefetch_count:
         ``0`` = synchronous (per-layer load/evict, lowest VRAM, slowest).
         ``>= 1`` = async prefetch this many layers ahead (faster, more VRAM).
@@ -275,7 +270,7 @@ class LayerOffloadWrapper(nn.Module):
         prefetch_count: int = 0,
     ) -> None:
         super().__init__()
-        _require_cuda(target_device)
+        _require_accelerator(target_device)
         if prefetch_count < 0:
             raise ValueError("prefetch_count must be >= 0")
         if model.training:
@@ -287,6 +282,7 @@ class LayerOffloadWrapper(nn.Module):
         self._model = model
         self._layers = _resolve_attr(model, layers_attr)
         self._target_device = target_device
+        self._accel = _accel(target_device)
         # Clamp: no point prefetching more layers than (num_layers - 1).
         max_prefetch = max(len(self._layers) - 1, 0)
         self._prefetch_count = min(prefetch_count, max_prefetch)
@@ -297,8 +293,9 @@ class LayerOffloadWrapper(nn.Module):
         # alloc/free pairing strategy: native allocator → record_stream
         # (fast, frees go to whatever stream is current); cudaMallocAsync →
         # wait_stream + free on prefetch stream (correct, slightly more
-        # serialized).
-        self._cuda_malloc_async = _is_cuda_malloc_async_backend()
+        # serialized). Only meaningful for CUDA; XPU always uses the native
+        # caching allocator and takes the record_stream fast path.
+        self._cuda_malloc_async = target_device.type == "cuda" and _is_cuda_malloc_async_backend()
         if self._async_mode:
             logger.info(
                 "LayerOffloadWrapper: async prefetch enabled (prefetch_count=%d, allocator=%s, free_path=%s)",
@@ -372,7 +369,7 @@ class LayerOffloadWrapper(nn.Module):
                     # Frees in _post_hook go to whatever stream is current
                     # (compute stream) and the allocator handles cross-stream
                     # reuse internally — no prefetch-stream barrier needed.
-                    compute_stream = torch.cuda.current_stream(self._target_device)
+                    compute_stream = self._accel.current_stream(self._target_device)
                     for param in itertools.chain(module.parameters(), module.buffers()):
                         param.data.record_stream(compute_stream)
 
@@ -395,9 +392,9 @@ class LayerOffloadWrapper(nn.Module):
                 # subsequent prefetches queued on the prefetch stream are
                 # ordered after this wait, slightly reducing pipeline depth.
                 prefetch_stream = self._prefetcher._stream  # type: ignore[union-attr]
-                compute_stream = torch.cuda.current_stream(self._target_device)
+                compute_stream = self._accel.current_stream(self._target_device)
                 prefetch_stream.wait_stream(compute_stream)
-                with torch.cuda.stream(prefetch_stream):
+                with self._accel.stream(prefetch_stream):
                     self._store.evict_to_cpu(idx, module)
             else:
                 # Native allocator path: just drop the GPU tensor refs on
@@ -447,8 +444,8 @@ class LayerOffloadWrapper(nn.Module):
             self._audit_handle = None
 
         # Drain in-flight H2D copies before tearing down stream resources, or
-        # the CUDA driver can hit use-after-free during cleanup.
-        torch.cuda.synchronize(device=self._target_device)
+        # the accelerator driver can hit use-after-free during cleanup.
+        self._accel.synchronize(device=self._target_device)
         if self._prefetcher is not None:
             self._prefetcher.cleanup()
             self._prefetcher = None

--- a/src/sensenova_u1/utils/offload.py
+++ b/src/sensenova_u1/utils/offload.py
@@ -17,6 +17,7 @@ from typing import TypeVar
 import torch
 from torch import nn
 
+from . import accel
 from .layer_offload import LayerOffloadWrapper
 
 LOGGER = logging.getLogger(__name__)
@@ -66,9 +67,8 @@ def make_offload_ctx(
 
 def _cleanup_memory() -> None:
     gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+    accel.empty_cache()
+    accel.synchronize()
 
 
 def _log_vram(label: str, target_device: torch.device) -> None:
@@ -78,11 +78,12 @@ def _log_vram(label: str, target_device: torch.device) -> None:
     ``vram_mode='balanced'``. Best-effort; never raises.
     """
     try:
-        if target_device.type != "cuda" or not torch.cuda.is_available():
+        if target_device.type not in accel.SUPPORTED_DEVICE_TYPES or not accel.is_available(target_device.type):
             return
-        alloc = torch.cuda.memory_allocated(target_device) / (1024**3)
-        reserved = torch.cuda.memory_reserved(target_device) / (1024**3)
-        peak = torch.cuda.max_memory_allocated(target_device) / (1024**3)
+        mod = accel.accel_module(target_device)
+        alloc = mod.memory_allocated(target_device) / (1024**3)
+        reserved = mod.memory_reserved(target_device) / (1024**3)
+        peak = mod.max_memory_allocated(target_device) / (1024**3)
         LOGGER.info(
             "[offload vram] %-40s | alloc=%6.2f GiB  reserved=%6.2f GiB  peak=%6.2f GiB",
             label,
@@ -98,12 +99,14 @@ def _empty_host_cache(target_device: torch.device) -> None:
     """Release PyTorch's pinned host-memory cache.
 
     Without this, repeated offload runs eventually exhaust host memory
-    because the CachingHostAllocator keeps freed pinned blocks cached.
+    because the CachingHostAllocator keeps freed pinned blocks cached. The
+    host cache is global (not per-backend); we still synchronize the active
+    accelerator first so in-flight H2D copies don't reference freed blocks.
     """
-    if not torch.cuda.is_available():
+    if target_device.type not in accel.SUPPORTED_DEVICE_TYPES or not accel.is_available(target_device.type):
         return
     try:
-        torch.cuda.synchronize(device=target_device)
+        accel.synchronize(target_device)
         if hasattr(torch._C, "_host_emptyCache"):
             torch._C._host_emptyCache()
     except Exception as exc:  # pragma: no cover - best-effort cleanup


### PR DESCRIPTION
## Summary

Adds Intel XPU support to the inference path so the same code runs on CUDA and XPU without forking call sites. Centralised in a new `utils/accel.py` helper that dispatches `torch.cuda` vs `torch.xpu` by device type; every site that used to call `torch.cuda.*` for stream / pin_memory / cache management now goes through it.

Public API for `LayerOffloadWrapper` is unchanged — passing `target_device=torch.device("xpu")` (or `cuda`) now both work.

## What changed

- **New:** `src/sensenova_u1/utils/accel.py` — `accel_module`, `require_accelerator`, `best_available_device`, `empty_cache`, `synchronize`, `manual_seed_all`, `is_available`.
- **`utils/layer_offload.py`** — `pin_memory(device=target_device.type)`; `Stream`, `Event`, `stream()`, `current_stream()`, `synchronize()` routed via `accel`; the `cudaMallocAsync` probe is now gated behind `device.type == "cuda"`, so XPU always takes the `record_stream` fast path.
- **`utils/offload.py`** — `_cleanup_memory`, `_log_vram`, `_empty_host_cache` no longer CUDA-gated.
- **`utils/checkpoint_loading.py`** — `device=None` auto-picks CUDA > XPU > CPU; final `empty_cache` runs through `accel`.
- **`models/neo_unify/modeling_neo_chat.py`** — replaces the CUDA-only `@torch.cuda.amp.autocast` decorator on `optimized_scale` with `torch.autocast(device_type=…)` chosen from the input tensor's device. Also removes the deprecation warning that decorator emitted on torch 2.8.
- **`models/neo_unify/modeling_qwen3.py`** — `_flash_or_sdpa` falls back to SDPA on non-CUDA devices even when `backend='flash'` (flash-attn ships CUDA kernels only).
- **`examples/{vqa,interleave,t2i,editing}/inference.py` + `apps/comfyui/{local_pipeline,nodes}.py`** — `--device` / node default resolves via `best_available_device()`; `_set_seed` covers XPU.

## Why this shape

A small dispatch helper rather than a runtime-injected accelerator object: the call sites are few, the surface (`Stream`, `Event`, `pin_memory`, `empty_cache`, `synchronize`) is tiny, and `accel_module(device)` keeps the code reading like the original `torch.cuda.*` calls. Targets PyTorch ≥ 2.5 where `torch.xpu` is in-tree — no IPEX import path.

## Test plan

- [x] AST + import sanity across all 13 changed files
- [x] `accel` helper routing unit-checked (cuda → `torch.cuda`, xpu → `torch.xpu`, cpu/mps rejected)
- [x] CUDA regression: `examples/t2i/inference.py` with `--vram_mode {full, low, balanced}` all produce expected outputs (verified on local GPU)
- [ ] XPU runtime validation pending hardware access (see staged plan below)

## Follow-up: XPU runtime validation

In order, once XPU hardware is available:

1. `--device xpu --vram_mode full --attn_backend sdpa` — minimal path, no offload
2. `--device xpu --vram_mode low` — sync offload, exercises XPU `pin_memory(device='xpu')`
3. `--device xpu --vram_mode balanced` — async prefetch, exercises XPU `Stream`/`Event`/`record_stream`. If VRAM grows unexpectedly, fall back to a "wait then evict" path equivalent to the `cudaMallocAsync` branch.

## Notes for reviewers

- Behaviour on CUDA should be bit-equivalent — the `accel` dispatch resolves to the same `torch.cuda.*` calls.
- The `@torch.cuda.amp.autocast` → `torch.autocast(device_type=…, enabled=False)` change at `modeling_neo_chat.py:95` is semantically equivalent (both force fp32 inside the block); double-check is welcome.
- `_flash_or_sdpa` will now silently fall back to SDPA on XPU even with `attn_backend='flash'` instead of crashing. Open to a louder warning if preferred.