### PR TITLE
deps: relax python from ==3.11 to >=3.10,<3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "SenseNova-U1: Unifying Multimodal Understanding and Generation with NEO-Unify Architecture."
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.10,<3.14"
 authors = [
     { name = "OpenSenseNova" },
 ]
@@ -19,7 +19,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: POSIX :: Linux",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -28,9 +31,12 @@ classifiers = [
 # Core dependencies.
 #
 # Versions here are pinned to match the internal reference environment
-# (`miniconda3/envs/lmms_engine`, Python 3.11, CUDA 12.8)
-# so that checkpoints trained there can be loaded and run bit-exactly. When
-# bumping any of these, please re-verify inference on a reference checkpoint.
+# (`miniconda3/envs/lmms_engine`, Python 3.11, CUDA 12.8) so that checkpoints
+# trained there can be loaded and run bit-exactly. Every pinned package below
+# ships wheels for CPython 3.10–3.13, which matches the project-wide
+# `requires-python` window; the 3.11 reference is for reproducibility, not a
+# language-feature requirement. When bumping any of these, please re-verify
+# inference on a reference checkpoint.
 dependencies = [
     "torch==2.8.0",
     "torchvision==0.23.0",
@@ -63,7 +69,9 @@ dependencies = [
 #
 # The reference env uses a cp311 / torch 2.8 wheel (`flash_attn 2.8.3`). PyPI
 # does not host CUDA-specific wheels, so users will typically install this
-# manually from a local .whl that matches their torch + Python combination, e.g.:
+# manually from a local .whl that matches their torch + Python combination
+# (replace `cp311` with your interpreter's tag — cp310/cp311/cp312/cp313 are
+# all supported by upstream flash-attn releases), e.g.:
 #
 #   uv pip install /path/to/flash_attn-2.8.3+cu12torch28cxx11abitrue-cp311-cp311-*.whl
 flash = [
@@ -114,7 +122,7 @@ explicit = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py311"
+target-version = "py310"
 extend-exclude = [
     "src/sensenova_u1/models/neo_unify",
     # Vendored verbatim from SenseNova-Skills; keep diff-clean for easy uprev.


### PR DESCRIPTION
## Summary

Relax `requires-python` from `>=3.11,<3.12` to `>=3.10,<3.14` so users on ComfyUI's bundled Python (3.12/3.13), Colab (3.11), and the majority of conda / cluster environments (3.10/3.11/3.12) can `pip install` without resolver gymnastics. Pillow / numpy / torch pins are **unchanged** so checkpoint loading stays bit-exact against the internal reference env.

## Why this is safe

**Dependencies don't need 3.11.** Checked every pinned package's `requires_python` and wheel matrix on PyPI:

| package | version | requires_python | wheels |
|---|---|---|---|
| pillow | 12.0.0 | >=3.10 | cp310–cp314 |
| numpy | 2.2.x | >=3.10 | cp310–cp313 |
| torch | 2.8.0 | >=3.9 | cp39–**cp313** (upper bound) |
| transformers / tokenizers / accelerate / safetensors / sentencepiece | various | >=3.9 | … |

Bottom: `pillow` and `numpy` (3.10). Top: `torch` wheels (3.13). The window `>=3.10,<3.14` is the maximum compatible with the current pin set.

**Source code doesn't need 3.11 either.** Swept `src/sensenova_u1`, `apps/comfyui`, `examples/`:
- no `match/case`, no `tomllib`, no `typing.Self / TypeAlias / ParamSpec`
- no runtime `X | Y` unions (e.g. `isinstance(x, A | B)`)
- every annotated module already opts into `from __future__ import annotations`, so type-hint `|` syntax is string-deferred

`training/` was intentionally not audited — it sits behind its own `requirements.txt` and is out of scope for the inference / ComfyUI install path.

## Other changes in this PR

- `classifiers`: list 3.10, 3.11, 3.12, 3.13
- `ruff target-version`: `py311` → `py310`
- comments around the flash extra and the dependency block clarified — the `cp311` wheel tag in the flash-attn install hint is now flagged as illustrative (replace with `cp310/cp311/cp312/cp313` to match your interpreter)
- comment above the core `dependencies` block notes that the 3.11 reference env is for reproducibility, not a language-feature requirement

## Test plan

- [ ] `uv sync` (or `pip install -e .`) on Python 3.10
- [ ] `uv sync` on Python 3.11 (existing reference env — regression check)
- [ ] `uv sync` on Python 3.12 (ComfyUI bundled Python)
- [ ] `uv sync` on Python 3.13
- [ ] Run one inference example end-to-end on at least 3.10 and 3.12 to confirm no runtime surprises beyond what the static scan caught