### PR TITLE
feat: offload token embedding and LM head in VRAM modes

### DIFF
--- a/src/sensenova_u1/utils/__init__.py
+++ b/src/sensenova_u1/utils/__init__.py
@@ -14,6 +14,7 @@ from .comparison import save_compare
 from .gguf_loader import load_gguf_checkpoint, match_state_dict, set_gguf2meta_model
 from .lora import load_and_merge_lora_weight_from_safetensors
 from .offload import (
+    DEFAULT_AUXILIARY_OFFLOAD_ATTRS,
     DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
     DEFAULT_FAST_VRAM_FRACTION,
     DEFAULT_FAST_VRAM_HEADROOM_GIB,
@@ -35,6 +36,7 @@ from .param_count import (
 from .profiler import DEFAULT_IMAGE_PATCH_SIZE, InferenceProfiler
 
 __all__ = [
+    "DEFAULT_AUXILIARY_OFFLOAD_ATTRS",
     "DEFAULT_FAST_ACTIVATION_RESERVE_GIB",
     "DEFAULT_FAST_VRAM_FRACTION",
     "DEFAULT_FAST_VRAM_HEADROOM_GIB",

--- a/src/sensenova_u1/utils/layer_offload.py
+++ b/src/sensenova_u1/utils/layer_offload.py
@@ -119,6 +119,31 @@ def _resolve_attr(module: nn.Module, dotted_path: str) -> nn.ModuleList:
     return obj
 
 
+def _resolve_optional_module_attrs(module: nn.Module, dotted_paths: tuple[str, ...]) -> list[tuple[str, nn.Module]]:
+    """Resolve optional dotted module paths, skipping missing paths.
+
+    This keeps the wrapper generic: NEO-Unify can offload known large
+    non-layer modules, while other models simply ignore those paths.
+    """
+    modules: list[tuple[str, nn.Module]] = []
+    seen: set[int] = set()
+    for dotted_path in dotted_paths:
+        obj: Any = module
+        try:
+            for part in dotted_path.split("."):
+                obj = getattr(obj, part)
+        except AttributeError:
+            logger.debug("LayerOffloadWrapper: optional module %r was not found; skipping", dotted_path)
+            continue
+        if not isinstance(obj, nn.Module):
+            raise TypeError(f"Expected nn.Module at '{dotted_path}', got {type(obj).__name__}")
+        if id(obj) in seen:
+            continue
+        seen.add(id(obj))
+        modules.append((dotted_path, obj))
+    return modules
+
+
 def _partition_layer_tensor_names(layer: nn.Module) -> dict[str, str]:
     """Classify layer tensors into shared, understanding, and generation groups.
 
@@ -233,12 +258,14 @@ class _LayerStore:
         self._tensor_groups: list[dict[str, str]] = []
         self._resident_groups: list[set[str]] = []
         self._on_gpu: set[int] = set()
+        self._managed_tensor_ids: set[int] = set()
         self._bytes_moved = 0
         self._bytes_moved_by_group = {group: 0 for group in _ALL_TENSOR_GROUPS}
 
         for layer in layers:
             pinned: dict[str, torch.Tensor] = {}
             for name, tensor in itertools.chain(layer.named_parameters(), layer.named_buffers()):
+                self._managed_tensor_ids.add(id(tensor))
                 pinned_tensor = tensor.data.pin_memory(device=self._pin_device)
                 tensor.data = pinned_tensor
                 pinned[name] = pinned_tensor
@@ -331,11 +358,7 @@ class _LayerStore:
         )
 
     def managed_tensor_ids(self) -> set[int]:
-        ids: set[int] = set()
-        for pinned in self._pinned:
-            for t in pinned.values():
-                ids.add(id(t))
-        return ids
+        return set(self._managed_tensor_ids)
 
     def cleanup(self) -> None:
         """Drop the pinned-tensor refs so they can be freed by the GC."""
@@ -345,6 +368,87 @@ class _LayerStore:
         self._tensor_groups.clear()
         self._resident_groups.clear()
         self._on_gpu.clear()
+        self._managed_tensor_ids.clear()
+
+
+class _AuxiliaryModuleStore:
+    """CPU-pinned store for large non-layer modules used only in prefix/text phases."""
+
+    def __init__(
+        self,
+        modules: list[tuple[str, nn.Module]],
+        target_device: torch.device,
+        *,
+        exclude_tensor_ids: set[int],
+    ) -> None:
+        self.target_device = target_device
+        self._pin_device = target_device.type
+        self._pinned: dict[int, torch.Tensor] = {}
+        self._module_tensor_ids: dict[int, set[int]] = {}
+        self._managed_tensor_ids: set[int] = set()
+        self._bytes_moved = 0
+
+        for path, module in modules:
+            tensor_ids: set[int] = set()
+            for tensor in itertools.chain(module.parameters(), module.buffers()):
+                tensor_id = id(tensor)
+                if tensor_id in exclude_tensor_ids:
+                    continue
+                tensor_ids.add(tensor_id)
+                self._managed_tensor_ids.add(tensor_id)
+                if tensor_id not in self._pinned:
+                    pinned_tensor = tensor.data.pin_memory(device=self._pin_device)
+                    tensor.data = pinned_tensor
+                    self._pinned[tensor_id] = pinned_tensor
+            if tensor_ids:
+                self._module_tensor_ids[id(module)] = tensor_ids
+                total_bytes = sum(
+                    self._pinned[tensor_id].numel() * self._pinned[tensor_id].element_size() for tensor_id in tensor_ids
+                )
+                logger.info(
+                    "LayerOffloadWrapper: auxiliary module %r offloaded to pinned CPU (%.2f GiB)",
+                    path,
+                    total_bytes / _GIB,
+                )
+
+    def has_tensors(self, module: nn.Module) -> bool:
+        return bool(self._module_tensor_ids.get(id(module)))
+
+    def move_to_gpu(self, module: nn.Module, *, non_blocking: bool = False) -> None:
+        tensor_ids = self._module_tensor_ids.get(id(module))
+        if not tensor_ids:
+            return
+        for tensor in itertools.chain(module.parameters(), module.buffers()):
+            tensor_id = id(tensor)
+            if tensor_id in tensor_ids:
+                source = self._pinned[tensor_id]
+                if tensor.device != self.target_device:
+                    tensor.data = source.to(self.target_device, non_blocking=non_blocking)
+                    self._bytes_moved += source.numel() * source.element_size()
+
+    def evict_to_cpu(self, module: nn.Module) -> None:
+        tensor_ids = self._module_tensor_ids.get(id(module))
+        if not tensor_ids:
+            return
+        for tensor in itertools.chain(module.parameters(), module.buffers()):
+            tensor_id = id(tensor)
+            if tensor_id in tensor_ids:
+                tensor.data = self._pinned[tensor_id]
+
+    def evict_all(self, modules: list[tuple[str, nn.Module]]) -> None:
+        for _path, module in modules:
+            self.evict_to_cpu(module)
+
+    def managed_tensor_ids(self) -> set[int]:
+        return set(self._managed_tensor_ids)
+
+    def transfer_stats(self) -> int:
+        return self._bytes_moved
+
+    def cleanup(self) -> None:
+        self._pinned.clear()
+        self._module_tensor_ids.clear()
+        self._managed_tensor_ids.clear()
 
 
 class _AsyncPrefetcher:
@@ -424,6 +528,9 @@ class LayerOffloadWrapper(nn.Module):
         happens after the decoder-layer hooks.
     fast_vram_budget_gib:
         Optional absolute budget overriding ``fast_vram_fraction``.
+    offload_auxiliary_attrs:
+        Optional dotted module paths outside ``layers_attr`` that should be
+        moved onto GPU only around their own forward calls.
     """
 
     def __init__(
@@ -437,6 +544,7 @@ class LayerOffloadWrapper(nn.Module):
         fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
         fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
         fast_vram_budget_gib: float | None = None,
+        offload_auxiliary_attrs: tuple[str, ...] = (),
     ) -> None:
         super().__init__()
         _require_accelerator(target_device)
@@ -450,6 +558,9 @@ class LayerOffloadWrapper(nn.Module):
 
         self._model = model
         self._layers = _resolve_attr(model, layers_attr)
+        self._offload_auxiliary_attrs = offload_auxiliary_attrs
+        self._auxiliary_modules: list[tuple[str, nn.Module]] = []
+        self._auxiliary_store: _AuxiliaryModuleStore | None = None
         self._target_device = target_device
         self._accel = _accel(target_device)
         # Clamp: no point prefetching more layers than (num_layers - 1).
@@ -527,30 +638,41 @@ class LayerOffloadWrapper(nn.Module):
     def _setup(self) -> None:
         # 1. Pin all layer tensors in CPU memory.
         self._store = _LayerStore(self._layers, self._target_device)
-
-        # 2. Move all NON-layer params/buffers to GPU permanently.
         layer_tensor_ids: set[int] = set()
         for layer in self._layers:
             for t in itertools.chain(layer.parameters(), layer.buffers()):
                 layer_tensor_ids.add(id(t))
 
+        # 2. Pin selected large non-layer modules in CPU memory. These are
+        #    temporarily moved to GPU by their own forward hooks instead of
+        #    remaining resident throughout denoising.
+        self._auxiliary_modules = _resolve_optional_module_attrs(self._model, self._offload_auxiliary_attrs)
+        self._auxiliary_store = _AuxiliaryModuleStore(
+            self._auxiliary_modules,
+            self._target_device,
+            exclude_tensor_ids=layer_tensor_ids,
+        )
+
+        managed_tensor_ids = layer_tensor_ids | self._auxiliary_store.managed_tensor_ids()
+
+        # 3. Move all permanently-resident params/buffers to GPU.
         for p in self._model.parameters():
-            if id(p) not in layer_tensor_ids:
+            if id(p) not in managed_tensor_ids:
                 p.data = p.data.to(self._target_device)
         for b in self._model.buffers():
-            if id(b) not in layer_tensor_ids:
+            if id(b) not in managed_tensor_ids:
                 b.data = b.data.to(self._target_device)
 
-        # 3. In async mode spin up the prefetch stream. The first weights are
+        # 4. In async mode spin up the prefetch stream. The first weights are
         #    loaded lazily because the layer kwargs tell us whether this pass
         #    needs the understanding branch or the generation branch.
         if self._async_mode:
             self._prefetcher = _AsyncPrefetcher(self._store, self._layers)
 
-        # 4. Register layer load/evict hooks.
+        # 5. Register layer and auxiliary-module load/evict hooks.
         self._register_hooks()
 
-        # 5. One-shot audit: catch lazy params/buffers materialised inside the
+        # 6. One-shot audit: catch lazy params/buffers materialised inside the
         #    first forward (RoPE caches, attention masks, etc.) that escaped
         #    the construction-time scan.
         self._audit_handle = self._model.register_forward_hook(self._audit_first_forward)
@@ -669,9 +791,28 @@ class LayerOffloadWrapper(nn.Module):
             h2 = layer.register_forward_hook(functools.partial(_post_hook, idx=idx))
             self._hooks.extend([h1, h2])
 
+        def _aux_pre_hook(module: nn.Module, _args: Any) -> None:
+            if self._auxiliary_store is not None:
+                self._auxiliary_store.move_to_gpu(module, non_blocking=True)
+
+        def _aux_post_hook(module: nn.Module, _args: Any, _output: Any) -> None:
+            if self._auxiliary_store is not None:
+                self._auxiliary_store.evict_to_cpu(module)
+
+        if self._auxiliary_store is not None:
+            for _path, module in self._auxiliary_modules:
+                if not self._auxiliary_store.has_tensors(module):
+                    continue
+                h1 = module.register_forward_pre_hook(_aux_pre_hook)
+                h2 = module.register_forward_hook(_aux_post_hook)
+                self._hooks.extend([h1, h2])
+
     def _audit_first_forward(self, _module: nn.Module, _inputs: Any, _outputs: Any) -> None:
         _log_vram("wrapper.audit: pre", self._target_device)
-        moved = _audit_lazy_state(self._model, self._target_device, self._store.managed_tensor_ids())
+        managed_tensor_ids = self._store.managed_tensor_ids()
+        if self._auxiliary_store is not None:
+            managed_tensor_ids |= self._auxiliary_store.managed_tensor_ids()
+        moved = _audit_lazy_state(self._model, self._target_device, managed_tensor_ids)
         if moved:
             logger.warning(
                 "LayerOffloadWrapper: moved %d lazy param(s)/buffer(s) onto %s after "
@@ -717,6 +858,8 @@ class LayerOffloadWrapper(nn.Module):
             self._store.evict_to_cpu(idx, layer)
         self._resident_generation_layers.clear()
         self._resident_generation_bytes = 0
+        if self._auxiliary_store is not None:
+            self._auxiliary_store.evict_all(self._auxiliary_modules)
 
         for p in self._model.parameters():
             p.data = p.data.to("cpu")
@@ -724,14 +867,21 @@ class LayerOffloadWrapper(nn.Module):
             b.data = b.data.to("cpu")
 
         total_bytes, by_group = self._store.transfer_stats()
+        auxiliary_bytes = 0 if self._auxiliary_store is None else self._auxiliary_store.transfer_stats()
         logger.info(
-            "LayerOffloadWrapper transfer totals: %.2f GiB (shared=%.2f, understanding=%.2f, generation=%.2f)",
+            "LayerOffloadWrapper transfer totals: %.2f GiB "
+            "(shared=%.2f, understanding=%.2f, generation=%.2f, auxiliary=%.2f)",
             total_bytes / (1024**3),
             by_group[_GROUP_SHARED] / (1024**3),
             by_group[_GROUP_UNDERSTANDING] / (1024**3),
             by_group[_GROUP_GENERATION] / (1024**3),
+            auxiliary_bytes / (1024**3),
         )
         self._store.cleanup()
+        if self._auxiliary_store is not None:
+            self._auxiliary_store.cleanup()
+            self._auxiliary_store = None
+        self._auxiliary_modules.clear()
         _log_vram("wrapper.teardown: exit (pre-empty_cache)", self._target_device)
 
     # ------------------------------------------------------------------

--- a/src/sensenova_u1/utils/offload.py
+++ b/src/sensenova_u1/utils/offload.py
@@ -38,6 +38,10 @@ _VRAM_MODE_TO_PREFETCH: dict[str, int] = {
     "balanced": 2,
 }
 DEFAULT_LAYERS_ATTR: str = "language_model.model.layers"
+DEFAULT_AUXILIARY_OFFLOAD_ATTRS: tuple[str, ...] = (
+    "language_model.model.embed_tokens",
+    "language_model.lm_head",
+)
 
 
 def vram_mode_to_prefetch_count(mode: str) -> int:
@@ -69,6 +73,7 @@ def make_offload_ctx(
     fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
     fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
     fast_vram_budget_gib: float | None = None,
+    offload_auxiliary_attrs: tuple[str, ...] = DEFAULT_AUXILIARY_OFFLOAD_ATTRS,
 ) -> AbstractContextManager[nn.Module]:
     """Pick the right offload context for ``prefetch_count``.
 
@@ -89,6 +94,7 @@ def make_offload_ctx(
             fast_vram_headroom_gib=fast_vram_headroom_gib,
             fast_activation_reserve_gib=fast_activation_reserve_gib,
             fast_vram_budget_gib=fast_vram_budget_gib,
+            offload_auxiliary_attrs=offload_auxiliary_attrs,
         )
     return offload_layers_async(
         model,
@@ -100,6 +106,7 @@ def make_offload_ctx(
         fast_vram_headroom_gib=fast_vram_headroom_gib,
         fast_activation_reserve_gib=fast_activation_reserve_gib,
         fast_vram_budget_gib=fast_vram_budget_gib,
+        offload_auxiliary_attrs=offload_auxiliary_attrs,
     )
 
 
@@ -162,6 +169,7 @@ def _offload_layers(
     fast_vram_headroom_gib: float,
     fast_activation_reserve_gib: float,
     fast_vram_budget_gib: float | None,
+    offload_auxiliary_attrs: tuple[str, ...],
 ) -> Iterator[nn.Module]:
     wrapper = LayerOffloadWrapper(
         model,
@@ -173,6 +181,7 @@ def _offload_layers(
         fast_vram_headroom_gib=fast_vram_headroom_gib,
         fast_activation_reserve_gib=fast_activation_reserve_gib,
         fast_vram_budget_gib=fast_vram_budget_gib,
+        offload_auxiliary_attrs=offload_auxiliary_attrs,
     )
     try:
         yield wrapper
@@ -202,6 +211,7 @@ def offload_layers_sync(
     fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
     fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
     fast_vram_budget_gib: float | None = None,
+    offload_auxiliary_attrs: tuple[str, ...] = DEFAULT_AUXILIARY_OFFLOAD_ATTRS,
 ) -> AbstractContextManager[nn.Module]:
     """Synchronous CPU<->GPU layer offload. Lower memory, slower.
 
@@ -218,6 +228,7 @@ def offload_layers_sync(
         fast_vram_headroom_gib=fast_vram_headroom_gib,
         fast_activation_reserve_gib=fast_activation_reserve_gib,
         fast_vram_budget_gib=fast_vram_budget_gib,
+        offload_auxiliary_attrs=offload_auxiliary_attrs,
     )
 
 
@@ -232,6 +243,7 @@ def offload_layers_async(
     fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
     fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
     fast_vram_budget_gib: float | None = None,
+    offload_auxiliary_attrs: tuple[str, ...] = DEFAULT_AUXILIARY_OFFLOAD_ATTRS,
 ) -> AbstractContextManager[nn.Module]:
     """Async-prefetch layer offload. Higher memory, faster.
 
@@ -250,4 +262,5 @@ def offload_layers_async(
         fast_vram_headroom_gib=fast_vram_headroom_gib,
         fast_activation_reserve_gib=fast_activation_reserve_gib,
         fast_vram_budget_gib=fast_vram_budget_gib,
+        offload_auxiliary_attrs=offload_auxiliary_attrs,
     )

--- a/tests/test_layer_offload.py
+++ b/tests/test_layer_offload.py
@@ -13,8 +13,10 @@ from sensenova_u1.utils.layer_offload import (
     _partition_layer_tensor_names,
     _required_tensor_groups,
     _resident_memory_limit,
+    _resolve_optional_module_attrs,
 )
 from sensenova_u1.utils.offload import (
+    DEFAULT_AUXILIARY_OFFLOAD_ATTRS,
     DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
     DEFAULT_FAST_VRAM_FRACTION,
     DEFAULT_FAST_VRAM_HEADROOM_GIB,
@@ -33,6 +35,16 @@ class _TwoBranchLayer(nn.Module):
         self.mlp = nn.Sequential(nn.Linear(4, 8, bias=False), nn.Linear(8, 4, bias=False))
         self.mlp_mot_gen = nn.Sequential(nn.Linear(4, 8, bias=False), nn.Linear(8, 4, bias=False))
         self.register_buffer("shared_scale", torch.ones(()))
+
+
+class _ModelWithOptionalModules(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.language_model = nn.Module()
+        self.language_model.model = nn.Module()
+        self.language_model.model.embed_tokens = nn.Embedding(8, 4)
+        self.language_model.lm_head = nn.Linear(4, 8, bias=False)
+        self.scalar = 1
 
 
 class LayerOffloadPartitionTest(unittest.TestCase):
@@ -112,9 +124,36 @@ class LayerOffloadPartitionTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             _resident_memory_limit(24 * gib, budget_bytes=0)
 
+    def test_optional_auxiliary_modules_skip_missing_paths_and_deduplicate(self) -> None:
+        model = _ModelWithOptionalModules()
+        modules = _resolve_optional_module_attrs(
+            model,
+            (
+                "language_model.model.embed_tokens",
+                "missing.path",
+                "language_model.lm_head",
+                "language_model.lm_head",
+            ),
+        )
+
+        self.assertEqual(
+            [path for path, _module in modules],
+            ["language_model.model.embed_tokens", "language_model.lm_head"],
+        )
+        self.assertIs(modules[0][1], model.language_model.model.embed_tokens)
+        self.assertIs(modules[1][1], model.language_model.lm_head)
+
+        with self.assertRaises(TypeError):
+            _resolve_optional_module_attrs(model, ("scalar",))
+
     def test_offload_cli_exposes_fast_mode_budget_controls(self) -> None:
         parser = argparse.ArgumentParser()
         add_offload_args(parser)
+
+        self.assertEqual(
+            DEFAULT_AUXILIARY_OFFLOAD_ATTRS,
+            ("language_model.model.embed_tokens", "language_model.lm_head"),
+        )
 
         defaults = parser.parse_args([])
         self.assertEqual(defaults.fast_vram_fraction, DEFAULT_FAST_VRAM_FRACTION)


### PR DESCRIPTION
I also validated the auxiliary offload change on U1.5 Preview with BF16 + SDPA, 50 steps, batch size 1, seeds 42/43/44. The comparison below uses peak VRAM as allocated / reserved GB.

| task | mode | before GB | after GB | delta allocated | delta reserved |
|---|---:|---:|---:|---:|---:|
| T2I | fast | 19.66 / 20.50 | 17.34 / 17.85 | -2.32 | -2.65 |
| T2I | balanced | 5.64 / 9.32 | 3.32 / 6.58 | -2.32 | -2.74 |
| T2I | low | 4.92 / 5.51 | 2.60 / 2.85 | -2.32 | -2.65 |
| Editing | fast | 22.29 / 24.94 | 19.97 / 22.67 | -2.32 | -2.27 |
| Editing | balanced | 10.31 / 14.04 | 7.99 / 11.77 | -2.32 | -2.27 |
| Editing | low | 9.59 / 11.01 | 7.27 / 8.75 | -2.32 | -2.27 |

The allocated peak consistently drops by ~2.32 GiB across all offload modes, which matches the expected BF16 footprint of `embed_tokens + lm_head`. Generation time stayed roughly unchanged overall.