### PR TITLE
chore(comfyui): prepare v0.2.0 release

### DIFF
--- a/apps/comfyui/README.md
+++ b/apps/comfyui/README.md
@@ -40,7 +40,7 @@ Before upgrading, remove or disable any manually copied legacy node directory
 such as `ComfyUI_SenseNova_U1`. Keeping both copies makes ComfyUI import the
 same node IDs twice, so the active implementation depends on scan order.
 
-Release 0.1.5 supports the `transformers>=4.57.1,<6` runtime range. Core
+Release 0.2.0 supports the `transformers>=4.57.1,<6` runtime range. Core
 compatibility is continuously checked against the minimum/final v4 releases
 and the latest v5 release; local U1.5 text-to-image and image-edit inference
 has also been verified through ComfyUI with Transformers 5.x.

--- a/apps/comfyui/pyproject.toml
+++ b/apps/comfyui/pyproject.toml
@@ -8,7 +8,7 @@
 # under this directory.
 [project]
 name = "ComfyUI-SenseNova-U1"
-version = "0.1.5"
+version = "0.2.0"
 description = "SenseNova-U1 custom nodes for ComfyUI (API + local inference)."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -26,7 +26,7 @@ dependencies = [
     # Tarball URL (not git+https) so pip skips submodule init; see
     # requirements.txt for the full rationale. Keep this aligned with the
     # monorepo's comfyui-vX.Y.Z release tag for reproducible installs.
-    "sensenova-u1 @ https://github.com/OpenSenseNova/SenseNova-U1/archive/refs/tags/comfyui-v0.1.5.tar.gz",
+    "sensenova-u1 @ https://github.com/OpenSenseNova/SenseNova-U1/archive/refs/tags/comfyui-v0.2.0.tar.gz",
 ]
 
 [project.urls]

--- a/apps/comfyui/requirements.txt
+++ b/apps/comfyui/requirements.txt
@@ -9,4 +9,4 @@ python-dotenv
 # Monorepo developers can install the four packages above directly, followed
 # by `pip install -e .` from the repo root. Registry releases use the matching
 # monorepo tag so installs do not drift with main.
-sensenova-u1 @ https://github.com/OpenSenseNova/SenseNova-U1/archive/refs/tags/comfyui-v0.1.5.tar.gz
+sensenova-u1 @ https://github.com/OpenSenseNova/SenseNova-U1/archive/refs/tags/comfyui-v0.2.0.tar.gz


### PR DESCRIPTION
## Summary

- bump the ComfyUI custom node package to 0.2.0
- pin the bundled `sensenova-u1` dependency to `comfyui-v0.2.0`
- update the ComfyUI release documentation

## Validation

- 33 tests passed
- pre-commit passed
- release tag/version/dependency metadata consistency check passed
