### PR TITLE
fix(comfyui): harden local loader startup

### DIFF
--- a/apps/comfyui/local_pipeline.py
+++ b/apps/comfyui/local_pipeline.py
@@ -241,7 +241,7 @@ class SenseNovaU1LocalModel:
         prefetch_count = _VRAM_MODE_TO_PREFETCH[vram_mode]
 
         injected_path = _maybe_add_source_path(sensenova_u1_src)
-        model_path = _resolve_local_model_path(model_path)
+        model_path = model_path.strip()
         torch = _import_torch()
         sensenova_u1, load_model_and_tokenizer, _ = _import_sensenova_u1()
 
@@ -781,17 +781,6 @@ def _import_sensenova_u1():
             "(or fill the loader's `sensenova_u1_src` input)."
         ) from exc
     return sensenova_u1, load_model_and_tokenizer, smart_resize
-
-
-def _resolve_local_model_path(model_path: str) -> str:
-    if Path(model_path).exists():
-        return model_path
-    try:
-        from huggingface_hub import snapshot_download
-
-        return snapshot_download(model_path, local_files_only=True)
-    except Exception:
-        return model_path
 
 
 def _resolve_dtype(torch, dtype: str):

--- a/apps/comfyui/nodes.py
+++ b/apps/comfyui/nodes.py
@@ -156,6 +156,25 @@ def _resolve_gguf_choice(value: str) -> str:
     return value
 
 
+def _normalize_fast_settings(
+    fast_vram_fraction: float | str | None,
+    fast_vram_headroom_gib: float | str | None,
+    fast_activation_reserve_gib: float | str | None,
+    fast_vram_budget_gib: float | str | None,
+) -> tuple[float, float, float, float]:
+    def value_or_default(value: float | str | None, default: float) -> float:
+        if value is None or (isinstance(value, str) and not value.strip()):
+            return default
+        return float(value)
+
+    return (
+        value_or_default(fast_vram_fraction, DEFAULT_FAST_VRAM_FRACTION),
+        value_or_default(fast_vram_headroom_gib, DEFAULT_FAST_VRAM_HEADROOM_GIB),
+        value_or_default(fast_activation_reserve_gib, DEFAULT_FAST_ACTIVATION_RESERVE_GIB),
+        value_or_default(fast_vram_budget_gib, 0.0),
+    )
+
+
 _LOCAL_MODEL_CACHE: dict[tuple, SenseNovaU1LocalModel] = {}
 
 
@@ -530,45 +549,33 @@ class SenseNovaU1LocalLoader(io.ComfyNode):
                         "ComfyUI to refresh the list after dropping new files into either folder."
                     ),
                 ),
-                io.Float.Input(
+                io.String.Input(
                     "fast_vram_fraction",
-                    default=DEFAULT_FAST_VRAM_FRACTION,
-                    min=0.1,
-                    max=1.0,
-                    step=0.01,
+                    default=str(DEFAULT_FAST_VRAM_FRACTION),
                     optional=True,
                     advanced=True,
-                    tooltip="Automatic fast-mode VRAM budget as a fraction of physical memory.",
+                    tooltip="Automatic fast-mode VRAM fraction (0 < value <= 1). Blank uses the default.",
                 ),
-                io.Float.Input(
+                io.String.Input(
                     "fast_vram_headroom_gib",
-                    default=DEFAULT_FAST_VRAM_HEADROOM_GIB,
-                    min=0.0,
-                    max=32.0,
-                    step=0.25,
+                    default=str(DEFAULT_FAST_VRAM_HEADROOM_GIB),
                     optional=True,
                     advanced=True,
-                    tooltip="Reusable VRAM headroom reserved after projected activation growth.",
+                    tooltip="Reusable VRAM headroom in GiB. Blank uses the default.",
                 ),
-                io.Float.Input(
+                io.String.Input(
                     "fast_activation_reserve_gib",
-                    default=DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
-                    min=0.0,
-                    max=32.0,
-                    step=0.25,
+                    default=str(DEFAULT_FAST_ACTIVATION_RESERVE_GIB),
                     optional=True,
                     advanced=True,
-                    tooltip="Allowance for activations allocated after decoder-layer forwards.",
+                    tooltip="Activation reserve in GiB. Blank uses the default.",
                 ),
-                io.Float.Input(
+                io.String.Input(
                     "fast_vram_budget_gib",
-                    default=0.0,
-                    min=0.0,
-                    max=128.0,
-                    step=0.25,
+                    default="0.0",
                     optional=True,
                     advanced=True,
-                    tooltip="Absolute fast-mode VRAM budget. 0 uses fast_vram_fraction.",
+                    tooltip="Absolute fast-mode VRAM budget in GiB. Blank or 0 uses fast_vram_fraction.",
                 ),
             ],
             outputs=[
@@ -589,11 +596,19 @@ class SenseNovaU1LocalLoader(io.ComfyNode):
         max_memory: str,
         vram_mode: str,
         gguf_checkpoint: str,
-        fast_vram_fraction: float = DEFAULT_FAST_VRAM_FRACTION,
-        fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
-        fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
-        fast_vram_budget_gib: float = 0.0,
+        fast_vram_fraction: float | str = DEFAULT_FAST_VRAM_FRACTION,
+        fast_vram_headroom_gib: float | str = DEFAULT_FAST_VRAM_HEADROOM_GIB,
+        fast_activation_reserve_gib: float | str = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+        fast_vram_budget_gib: float | str = 0.0,
     ) -> str:
+        fast_vram_fraction, fast_vram_headroom_gib, fast_activation_reserve_gib, fast_vram_budget_gib = (
+            _normalize_fast_settings(
+                fast_vram_fraction,
+                fast_vram_headroom_gib,
+                fast_activation_reserve_gib,
+                fast_vram_budget_gib,
+            )
+        )
         key = (
             model_path.strip(),
             sensenova_u1_src.strip(),
@@ -623,11 +638,19 @@ class SenseNovaU1LocalLoader(io.ComfyNode):
         max_memory: str,
         vram_mode: str,
         gguf_checkpoint: str,
-        fast_vram_fraction: float = DEFAULT_FAST_VRAM_FRACTION,
-        fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
-        fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
-        fast_vram_budget_gib: float = 0.0,
+        fast_vram_fraction: float | str = DEFAULT_FAST_VRAM_FRACTION,
+        fast_vram_headroom_gib: float | str = DEFAULT_FAST_VRAM_HEADROOM_GIB,
+        fast_activation_reserve_gib: float | str = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+        fast_vram_budget_gib: float | str = 0.0,
     ) -> io.NodeOutput:
+        fast_vram_fraction, fast_vram_headroom_gib, fast_activation_reserve_gib, fast_vram_budget_gib = (
+            _normalize_fast_settings(
+                fast_vram_fraction,
+                fast_vram_headroom_gib,
+                fast_activation_reserve_gib,
+                fast_vram_budget_gib,
+            )
+        )
         resolved_gguf = _resolve_gguf_choice(gguf_checkpoint.strip())
         cache_key = (
             model_path.strip(),

--- a/src/sensenova_u1/utils/checkpoint_loading.py
+++ b/src/sensenova_u1/utils/checkpoint_loading.py
@@ -146,20 +146,37 @@ def infer_input_device(model: nn.Module, fallback: str | torch.device | None = N
 
 
 def _resolve_local_model_path(model_path: str) -> str:
-    """Resolve a HF id to its cached snapshot directory when offline.
+    """Resolve a HF id to a complete cached snapshot directory when offline.
 
     Mirrors transformers' fall-back behaviour but skips the up-front HEAD
-    request that times out on offline machines. Returns the input unchanged
-    if the path already exists or no cached snapshot is found.
+    request that times out on offline machines. A partially cached snapshot
+    must not shadow the Hub id, because Transformers would then treat it as a
+    local directory and lose the opportunity to fetch its missing weights.
     """
     if Path(model_path).exists():
         return model_path
     try:
         from huggingface_hub import snapshot_download
 
-        return snapshot_download(model_path, local_files_only=True)
+        snapshot = Path(snapshot_download(model_path, local_files_only=True))
     except Exception:
         return model_path
+    if _has_complete_model_weights(snapshot):
+        return str(snapshot)
+    return model_path
+
+
+def _has_complete_model_weights(snapshot: Path) -> bool:
+    for index_name in ("model.safetensors.index.json", "pytorch_model.bin.index.json"):
+        index_path = snapshot / index_name
+        if not index_path.is_file():
+            continue
+        try:
+            shard_names = set(json.loads(index_path.read_text())["weight_map"].values())
+        except (KeyError, TypeError, OSError, json.JSONDecodeError):
+            return False
+        return bool(shard_names) and all((snapshot / shard_name).is_file() for shard_name in shard_names)
+    return (snapshot / "model.safetensors").is_file() or (snapshot / "pytorch_model.bin").is_file()
 
 
 def load_model_and_tokenizer(

--- a/tests/test_checkpoint_loading.py
+++ b/tests/test_checkpoint_loading.py
@@ -1,0 +1,108 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import torch
+
+from sensenova_u1.utils.checkpoint_loading import load_model_and_tokenizer
+
+
+class _FakeModel:
+    def eval(self):
+        return self
+
+
+class CheckpointLoadingTest(unittest.TestCase):
+    def test_hf_id_is_preserved_when_cached_snapshot_has_no_weights(self) -> None:
+        model_id = "example/incomplete-cache"
+        calls: list[tuple[str, str]] = []
+        config = object()
+        tokenizer = object()
+
+        def load_config(path: str):
+            calls.append(("config", path))
+            return config
+
+        def load_tokenizer(path: str):
+            calls.append(("tokenizer", path))
+            return tokenizer
+
+        def load_model(path: str, **_kwargs):
+            calls.append(("model", path))
+            return _FakeModel()
+
+        with TemporaryDirectory() as directory:
+            incomplete_snapshot = Path(directory)
+            (incomplete_snapshot / "config.json").write_text("{}")
+            with (
+                mock.patch("huggingface_hub.snapshot_download", return_value=str(incomplete_snapshot)),
+                mock.patch("transformers.AutoConfig.from_pretrained", side_effect=load_config),
+                mock.patch("transformers.AutoTokenizer.from_pretrained", side_effect=load_tokenizer),
+                mock.patch("transformers.AutoModel.from_pretrained", side_effect=load_model),
+                mock.patch("sensenova_u1.check_checkpoint_compatibility"),
+            ):
+                model, loaded_tokenizer = load_model_and_tokenizer(
+                    model_id,
+                    dtype=torch.bfloat16,
+                    for_offload=True,
+                )
+
+        self.assertIsInstance(model, _FakeModel)
+        self.assertIs(loaded_tokenizer, tokenizer)
+        self.assertEqual(calls, [("config", model_id), ("tokenizer", model_id), ("model", model_id)])
+
+    def test_hf_id_is_preserved_when_cached_snapshot_is_missing_a_weight_shard(self) -> None:
+        model_id = "example/partial-shards"
+        calls: list[str] = []
+
+        with TemporaryDirectory() as directory:
+            snapshot = Path(directory)
+            (snapshot / "model.safetensors.index.json").write_text(
+                json.dumps(
+                    {
+                        "weight_map": {
+                            "layer.0": "model-00001-of-00002.safetensors",
+                            "layer.1": "model-00002-of-00002.safetensors",
+                        }
+                    }
+                )
+            )
+            (snapshot / "model-00001-of-00002.safetensors").touch()
+            with (
+                mock.patch("huggingface_hub.snapshot_download", return_value=str(snapshot)),
+                mock.patch(
+                    "transformers.AutoConfig.from_pretrained", side_effect=lambda path: calls.append(path) or object()
+                ),
+                mock.patch("transformers.AutoTokenizer.from_pretrained", return_value=object()),
+                mock.patch("transformers.AutoModel.from_pretrained", return_value=_FakeModel()),
+                mock.patch("sensenova_u1.check_checkpoint_compatibility"),
+            ):
+                load_model_and_tokenizer(model_id, dtype=torch.bfloat16, for_offload=True)
+
+        self.assertEqual(calls, [model_id])
+
+    def test_complete_cached_snapshot_remains_available_offline(self) -> None:
+        model_id = "example/complete-cache"
+        calls: list[str] = []
+
+        with TemporaryDirectory() as directory:
+            snapshot = Path(directory)
+            (snapshot / "model.safetensors").touch()
+            with (
+                mock.patch("huggingface_hub.snapshot_download", return_value=str(snapshot)),
+                mock.patch(
+                    "transformers.AutoConfig.from_pretrained", side_effect=lambda path: calls.append(path) or object()
+                ),
+                mock.patch("transformers.AutoTokenizer.from_pretrained", return_value=object()),
+                mock.patch("transformers.AutoModel.from_pretrained", return_value=_FakeModel()),
+                mock.patch("sensenova_u1.check_checkpoint_compatibility"),
+            ):
+                load_model_and_tokenizer(model_id, dtype=torch.bfloat16, for_offload=True)
+
+        self.assertEqual(calls, [str(snapshot)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_comfyui_workflow_compat.py
+++ b/tests/test_comfyui_workflow_compat.py
@@ -51,7 +51,7 @@ def _keyword(call: ast.Call, name: str) -> ast.expr | None:
 
 
 class ComfyUIWorkflowCompatibilityTest(unittest.TestCase):
-    def test_fast_settings_are_optional_widgets_appended_after_legacy_inputs(self) -> None:
+    def test_fast_settings_accept_blank_values_from_legacy_workflows(self) -> None:
         calls = _schema_input_calls(_loader_class())
         input_ids = [call.args[0].value for call in calls if call.args]
 
@@ -60,6 +60,7 @@ class ComfyUIWorkflowCompatibilityTest(unittest.TestCase):
 
         by_id = {call.args[0].value: call for call in calls if call.args}
         for input_id in FAST_LOADER_INPUTS:
+            self.assertEqual(ast.unparse(by_id[input_id].func), "io.String.Input")
             self.assertIsInstance(_keyword(by_id[input_id], "default"), ast.expr)
             self.assertIsInstance(_keyword(by_id[input_id], "optional"), ast.Constant)
             self.assertTrue(_keyword(by_id[input_id], "optional").value)


### PR DESCRIPTION
Fix two Local Loader startup regressions before the v0.2.0 tag is reissued.

- Do not let incomplete Hugging Face cache snapshots shadow the model ID.
- Accept blank legacy workflow values for the new fast VRAM settings.
- Remove duplicate cache resolution from the ComfyUI wrapper.

Validation: 36 tests passed; pre-commit passed; real U1 Loader succeeds on ml-cci-comfyui1.