### PR TITLE
perf(offload): accelerate thinking phase residency

### DIFF
--- a/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
+++ b/src/sensenova_u1/models/neo_unify/modeling_neo_chat.py
@@ -508,6 +508,10 @@ class NEOChatModel(PreTrainedModel):
         )
         return out.past_key_values, out.last_hidden_state
 
+    def _think_prefix_forward(self, **kwargs):
+        """Build the Think prefix cache without materialising per-token logits."""
+        return self.language_model(use_cache=True, logits_to_keep=1, **kwargs)
+
     def _append_text_tokens_to_cache(self, cache, t_idx, input_ids):
         if input_ids.shape[1] == 0:
             return t_idx
@@ -528,7 +532,7 @@ class NEOChatModel(PreTrainedModel):
         mask[:, :, :, past_len:] = causal_mask
         attention_mask_dict = {"full_attention": mask}
 
-        self.language_model(
+        self.language_model.model(
             inputs_embeds=inputs_embeds,
             indexes=indexes,
             attention_mask=attention_mask_dict,
@@ -1456,11 +1460,10 @@ class NEOChatModel(PreTrainedModel):
         )
 
         if think_mode:
-            outputs_condition = self.language_model(
+            outputs_condition = self._think_prefix_forward(
                 inputs_embeds=input_embeds_condition,
                 indexes=indexes_condition,
                 attention_mask=attention_mask_condition_prefix,
-                use_cache=True,
             )
             past_key_values_condition = outputs_condition.past_key_values
             device = outputs_condition.logits.device
@@ -1720,11 +1723,10 @@ class NEOChatModel(PreTrainedModel):
         )
 
         if think_mode:
-            outputs_condition = self.language_model(
+            outputs_condition = self._think_prefix_forward(
                 input_ids=input_ids_condition,
                 indexes=indexes_condition,
                 attention_mask=attention_mask_condition_prefix,
-                use_cache=True,
             )
             past_key_values_condition = outputs_condition.past_key_values
             device = outputs_condition.logits.device

--- a/src/sensenova_u1/utils/layer_offload.py
+++ b/src/sensenova_u1/utils/layer_offload.py
@@ -58,6 +58,11 @@ DEFAULT_FAST_VRAM_HEADROOM_GIB = 2.0
 DEFAULT_FAST_ACTIVATION_RESERVE_GIB = 4.0
 _PHASE_CALLBACK_ATTR = "_layer_offload_phase_callback"
 _MISSING = object()
+# The prefix understanding path uses eager attention with a float32 additive
+# mask.  At its peak, BF16 scores, promoted/masked scores, and float32 softmax
+# workspace overlap.  Twelve bytes per score is deliberately conservative and
+# matched the measured 8,442-token H100 peak with roughly 10% safety margin.
+_EAGER_ATTENTION_BYTES_PER_SCORE = 12
 
 
 def _resident_memory_limit(
@@ -526,6 +531,11 @@ class LayerOffloadWrapper(nn.Module):
         self._keep_generation_resident = keep_generation_resident
         self._resident_generation_layers: set[int] = set()
         self._resident_generation_bytes = 0
+        self._resident_understanding_layers: set[int] = set()
+        self._resident_understanding_bytes = 0
+        self._inference_phase: str | None = None
+        self._prefix_attention_reserve_bytes = 0
+        self._prefix_residency_active = False
         self._resident_memory_limit_bytes = 0
         if not math.isfinite(fast_vram_headroom_gib) or fast_vram_headroom_gib < 0:
             raise ValueError("fast_vram_headroom_gib must be finite and >= 0")
@@ -640,14 +650,22 @@ class LayerOffloadWrapper(nn.Module):
             # at a partially initialized wrapper.
             self._install_phase_callback()
 
-    def _switch_async_groups(self, groups: frozenset[str]) -> None:
+    def _switch_async_groups(self, groups: frozenset[str], *, force: bool = False) -> None:
         """Reset stale prefetch state when inference changes task branch."""
-        if self._active_groups == groups:
+        if self._active_groups == groups and not force:
             return
         if self._active_groups is not None:
             # Branch transitions are infrequent (typically prefix -> denoise).
             # A one-time drain is preferable to carrying the unused branch's
             # prefetched weights through every subsequent layer.
+            logger.info(
+                "LayerOffloadWrapper: branch transition %s -> %s "
+                "(understanding_resident=%.2f GiB, generation_resident=%.2f GiB)",
+                sorted(self._active_groups),
+                sorted(groups),
+                self._resident_understanding_bytes / _GIB,
+                self._resident_generation_bytes / _GIB,
+            )
             self._accel.synchronize(device=self._target_device)
             self._prefetcher.clear_events()  # type: ignore[union-attr]
             if self._cuda_malloc_async:
@@ -659,26 +677,35 @@ class LayerOffloadWrapper(nn.Module):
                     self._store.evict_to_cpu(idx, layer)
             self._resident_generation_layers.clear()
             self._resident_generation_bytes = 0
+            self._resident_understanding_layers.clear()
+            self._resident_understanding_bytes = 0
         self._active_groups = groups
+
+    def _can_keep_resident(self, activation_reserve_bytes: int) -> bool:
+        """Return whether current allocations plus workspace fit the fast watermark."""
+        allocated = int(self._accel.memory_allocated(self._target_device))
+        required_free_memory = self._resident_headroom_bytes + activation_reserve_bytes
+        try:
+            driver_free_memory = int(self._accel.mem_get_info(self._target_device)[0])
+            # cudaMallocAsync owns separate pools per stream in this wrapper;
+            # cached blocks from the prefetch stream cannot be assumed usable
+            # by attention work on the compute stream.
+            reclaimable_cache = 0
+            if not self._cuda_malloc_async:
+                reserved = int(self._accel.memory_reserved(self._target_device))
+                reclaimable_cache = max(reserved - allocated, 0)
+            effective_free_memory = driver_free_memory + reclaimable_cache
+        except Exception:  # pragma: no cover - backend-specific fallback
+            effective_free_memory = required_free_memory
+        projected_peak = allocated + activation_reserve_bytes
+        return projected_peak <= self._resident_memory_limit_bytes and effective_free_memory >= required_free_memory
 
     def _generation_groups_to_evict(self, idx: int, groups: frozenset[str]) -> frozenset[str]:
         """Keep generation weights resident while below the VRAM watermark."""
         if not self._keep_generation_resident or _GROUP_GENERATION not in groups:
             return groups
 
-        allocated = int(self._accel.memory_allocated(self._target_device))
-        required_free_memory = self._resident_headroom_bytes + self._activation_reserve_bytes
-        try:
-            driver_free_memory = int(self._accel.mem_get_info(self._target_device)[0])
-            reserved = int(self._accel.memory_reserved(self._target_device))
-            reclaimable_cache = max(reserved - allocated, 0)
-            effective_free_memory = driver_free_memory + reclaimable_cache
-        except Exception:  # pragma: no cover - backend-specific fallback
-            effective_free_memory = required_free_memory
-        projected_peak = allocated + self._activation_reserve_bytes
-        keep_resident = (
-            projected_peak <= self._resident_memory_limit_bytes and effective_free_memory >= required_free_memory
-        )
+        keep_resident = self._can_keep_resident(self._activation_reserve_bytes)
         group_bytes = self._store.group_nbytes(idx, _GROUP_GENERATION)
         if keep_resident:
             if idx not in self._resident_generation_layers:
@@ -690,15 +717,75 @@ class LayerOffloadWrapper(nn.Module):
             self._resident_generation_bytes -= group_bytes
         return groups
 
+    def _observe_prefix_forward(
+        self,
+        *,
+        query_length: int,
+        key_length: int,
+        batch_size: int,
+        num_heads: int,
+    ) -> None:
+        """Record the long-prefix workspace before retaining Think weights."""
+        if not self._keep_generation_resident or self._inference_phase != "prefix":
+            return
+        if min(query_length, key_length, batch_size, num_heads) <= 0:
+            return
+        if query_length > 1:
+            score_count = batch_size * num_heads * query_length * key_length
+            reserve = score_count * _EAGER_ATTENTION_BYTES_PER_SCORE
+            self._prefix_attention_reserve_bytes = max(self._prefix_attention_reserve_bytes, reserve)
+            return
+        if self._prefix_attention_reserve_bytes > 0:
+            self._prefix_residency_active = True
+
+    def _understanding_groups_to_evict(self, idx: int, groups: frozenset[str]) -> frozenset[str]:
+        """Retain Think-path weights when the measured prefix budget permits."""
+        if (
+            not self._keep_generation_resident
+            or self._inference_phase != "prefix"
+            or not self._prefix_residency_active
+            or _GROUP_UNDERSTANDING not in groups
+        ):
+            return groups
+
+        activation_reserve = max(self._activation_reserve_bytes, self._prefix_attention_reserve_bytes)
+        keep_resident = self._can_keep_resident(activation_reserve)
+        group_bytes = self._store.group_nbytes(idx, _GROUP_UNDERSTANDING)
+        if keep_resident:
+            if idx not in self._resident_understanding_layers:
+                self._resident_understanding_layers.add(idx)
+                self._resident_understanding_bytes += group_bytes
+            return groups - {_GROUP_UNDERSTANDING}
+        if idx in self._resident_understanding_layers:
+            self._resident_understanding_layers.remove(idx)
+            self._resident_understanding_bytes -= group_bytes
+        return groups
+
     def _register_hooks(self) -> None:
         idx_map: dict[int, int] = {id(layer): idx for idx, layer in enumerate(self._layers)}
         num_layers = len(self._layers)
 
         active_groups_by_layer: dict[int, frozenset[str]] = {}
 
-        def _pre_hook(module: nn.Module, _args: Any, kwargs: dict[str, Any], *, idx: int) -> None:
+        def _pre_hook(module: nn.Module, args: Any, kwargs: dict[str, Any], *, idx: int) -> None:
             groups = _required_tensor_groups(kwargs)
             active_groups_by_layer[idx] = groups
+            if idx == 0 and _GROUP_UNDERSTANDING in groups and args and isinstance(args[0], torch.Tensor):
+                hidden_states = args[0]
+                attention_mask = kwargs.get("attention_mask")
+                key_length = (
+                    int(attention_mask.shape[-1])
+                    if isinstance(attention_mask, torch.Tensor) and attention_mask.ndim >= 2
+                    else int(hidden_states.shape[-2])
+                )
+                attention_config = getattr(getattr(module, "self_attn", None), "config", None)
+                num_heads = int(getattr(attention_config, "num_attention_heads", 0))
+                self._observe_prefix_forward(
+                    query_length=int(hidden_states.shape[-2]),
+                    key_length=key_length,
+                    batch_size=int(hidden_states.shape[0]),
+                    num_heads=num_heads,
+                )
             if self._async_mode:
                 self._switch_async_groups(groups)
                 # Wait only for THIS layer's H2D transfer.
@@ -727,7 +814,8 @@ class LayerOffloadWrapper(nn.Module):
 
         def _post_hook(module: nn.Module, _args: Any, _output: Any, *, idx: int) -> None:
             groups = active_groups_by_layer.pop(idx, _ALL_TENSOR_GROUPS)
-            groups_to_evict = self._generation_groups_to_evict(idx, groups)
+            groups_to_evict = self._understanding_groups_to_evict(idx, groups)
+            groups_to_evict = self._generation_groups_to_evict(idx, groups_to_evict)
             if self._async_mode and self._cuda_malloc_async:
                 # cudaMallocAsync slow-but-safe path: per-stream pools
                 # require alloc and free on the same stream. Since
@@ -773,16 +861,46 @@ class LayerOffloadWrapper(nn.Module):
             self._audit_handle = None
 
     def set_inference_phase(self, phase: str) -> None:
-        """Move prefix-only weights for the next inference phase."""
+        """Swap branch and prefix-only weights for the next inference phase."""
         if phase not in {"prefix", "denoise"}:
             raise ValueError(f"Unsupported inference phase: {phase!r}")
-        if self._prefix_weight_store is None:
-            return
+        self._inference_phase = phase
         if phase == "prefix":
-            self._prefix_weight_store.move_to_target()
+            self._prefix_attention_reserve_bytes = 0
+            self._prefix_residency_active = False
+            if self._async_mode:
+                # A previous generation may have been cancelled during Think,
+                # before its denoise phase had a chance to release resident
+                # understanding weights. Always drain at a new run boundary.
+                self._switch_async_groups(
+                    frozenset({_GROUP_SHARED, _GROUP_UNDERSTANDING}),
+                    force=True,
+                )
+            else:
+                self._accel.synchronize(device=self._target_device)
+                for idx, layer in enumerate(self._layers):
+                    self._store.evict_to_cpu(idx, layer)
+                self._resident_generation_layers.clear()
+                self._resident_generation_bytes = 0
+                self._resident_understanding_layers.clear()
+                self._resident_understanding_bytes = 0
+            if self._prefix_weight_store is not None:
+                self._prefix_weight_store.move_to_target()
             return
-        self._accel.synchronize(device=self._target_device)
-        self._prefix_weight_store.evict_to_cpu()
+        if self._async_mode:
+            self._switch_async_groups(frozenset({_GROUP_SHARED, _GROUP_GENERATION}))
+        else:
+            self._accel.synchronize(device=self._target_device)
+            for idx, layer in enumerate(self._layers):
+                self._store.evict_to_cpu(
+                    idx,
+                    layer,
+                    groups=frozenset({_GROUP_UNDERSTANDING}),
+                )
+        self._resident_understanding_layers.clear()
+        self._resident_understanding_bytes = 0
+        if self._prefix_weight_store is not None:
+            self._prefix_weight_store.evict_to_cpu()
 
     def _install_phase_callback(self) -> None:
         self._previous_phase_callback = self._model.__dict__.get(_PHASE_CALLBACK_ATTR, _MISSING)
@@ -811,6 +929,8 @@ class LayerOffloadWrapper(nn.Module):
         _log_vram(
             f"wrapper.teardown: enter (on_gpu={len(self._store._on_gpu)}, "
             f"events={len(self._prefetcher._events) if self._prefetcher is not None else 0}, "
+            f"resident_understanding_layers={len(self._resident_understanding_layers)}, "
+            f"resident_understanding_gib={self._resident_understanding_bytes / _GIB:.2f}, "
             f"resident_generation_layers={len(self._resident_generation_layers)}, "
             f"resident_generation_gib={self._resident_generation_bytes / _GIB:.2f})",
             self._target_device,
@@ -837,6 +957,8 @@ class LayerOffloadWrapper(nn.Module):
             self._store.evict_to_cpu(idx, layer)
         self._resident_generation_layers.clear()
         self._resident_generation_bytes = 0
+        self._resident_understanding_layers.clear()
+        self._resident_understanding_bytes = 0
 
         for p in self._model.parameters():
             p.data = p.data.to("cpu")

--- a/tests/test_layer_offload.py
+++ b/tests/test_layer_offload.py
@@ -43,6 +43,15 @@ class _TwoBranchLayer(nn.Module):
         self.register_buffer("shared_scale", torch.ones(()))
 
 
+class _HookableTwoBranchLayer(_TwoBranchLayer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.self_attn.config = SimpleNamespace(num_attention_heads=4)
+
+    def forward(self, hidden_states: torch.Tensor, **_kwargs) -> torch.Tensor:
+        return hidden_states
+
+
 class LayerOffloadPartitionTest(unittest.TestCase):
     def test_layer_store_reports_parameter_identity_as_managed(self) -> None:
         parameter = Mock()
@@ -71,13 +80,29 @@ class LayerOffloadPartitionTest(unittest.TestCase):
         wrapper._prefix_weight_store = Mock()
         wrapper._accel = Mock()
         wrapper._target_device = torch.device("cuda")
+        wrapper._async_mode = True
+        wrapper._switch_async_groups = Mock()
+        wrapper._prefix_attention_reserve_bytes = 123
+        wrapper._prefix_residency_active = True
+        wrapper._resident_understanding_layers = {1, 2}
+        wrapper._resident_understanding_bytes = 456
 
         LayerOffloadWrapper.set_inference_phase(wrapper, "prefix")
+        wrapper._switch_async_groups.assert_called_once_with(
+            frozenset({_GROUP_SHARED, _GROUP_UNDERSTANDING}),
+            force=True,
+        )
         wrapper._prefix_weight_store.move_to_target.assert_called_once_with()
+        self.assertEqual(wrapper._inference_phase, "prefix")
+        self.assertEqual(wrapper._prefix_attention_reserve_bytes, 0)
+        self.assertFalse(wrapper._prefix_residency_active)
 
         LayerOffloadWrapper.set_inference_phase(wrapper, "denoise")
-        wrapper._accel.synchronize.assert_called_once_with(device=wrapper._target_device)
+        wrapper._switch_async_groups.assert_called_with(frozenset({_GROUP_SHARED, _GROUP_GENERATION}))
         wrapper._prefix_weight_store.evict_to_cpu.assert_called_once_with()
+        self.assertEqual(wrapper._inference_phase, "denoise")
+        self.assertEqual(wrapper._resident_understanding_layers, set())
+        self.assertEqual(wrapper._resident_understanding_bytes, 0)
 
         with self.assertRaisesRegex(ValueError, "Unsupported inference phase"):
             LayerOffloadWrapper.set_inference_phase(wrapper, "decode")
@@ -85,6 +110,60 @@ class LayerOffloadPartitionTest(unittest.TestCase):
         wrapper._prefix_weight_store = None
         with self.assertRaisesRegex(ValueError, "Unsupported inference phase"):
             LayerOffloadWrapper.set_inference_phase(wrapper, "decode")
+
+    def test_sync_phase_switch_evicts_resident_understanding_weights(self) -> None:
+        wrapper = object.__new__(LayerOffloadWrapper)
+        nn.Module.__init__(wrapper)
+        layer = Mock()
+        wrapper._layers = [layer]
+        wrapper._store = Mock()
+        wrapper._prefix_weight_store = None
+        wrapper._accel = Mock()
+        wrapper._target_device = torch.device("cuda")
+        wrapper._async_mode = False
+        wrapper._resident_understanding_layers = {0}
+        wrapper._resident_understanding_bytes = 123
+
+        LayerOffloadWrapper.set_inference_phase(wrapper, "denoise")
+
+        wrapper._accel.synchronize.assert_called_once_with(device=wrapper._target_device)
+        wrapper._store.evict_to_cpu.assert_called_once_with(
+            0,
+            layer,
+            groups=frozenset({_GROUP_UNDERSTANDING}),
+        )
+        self.assertEqual(wrapper._resident_understanding_layers, set())
+        self.assertEqual(wrapper._resident_understanding_bytes, 0)
+
+    def test_reentering_prefix_drains_residency_left_by_an_interrupted_run(self) -> None:
+        wrapper = object.__new__(LayerOffloadWrapper)
+        nn.Module.__init__(wrapper)
+        layer = Mock()
+        wrapper._layers = [layer]
+        wrapper._store = Mock()
+        wrapper._prefix_weight_store = None
+        wrapper._accel = Mock()
+        wrapper._target_device = torch.device("cuda")
+        wrapper._async_mode = True
+        wrapper._cuda_malloc_async = False
+        wrapper._prefetcher = Mock()
+        wrapper._active_groups = frozenset({_GROUP_SHARED, _GROUP_UNDERSTANDING})
+        wrapper._resident_generation_layers = set()
+        wrapper._resident_generation_bytes = 0
+        wrapper._resident_understanding_layers = {0}
+        wrapper._resident_understanding_bytes = 123
+        wrapper._prefix_attention_reserve_bytes = 456
+        wrapper._prefix_residency_active = True
+
+        LayerOffloadWrapper.set_inference_phase(wrapper, "prefix")
+
+        wrapper._accel.synchronize.assert_called_once_with(device=wrapper._target_device)
+        wrapper._prefetcher.clear_events.assert_called_once_with()
+        wrapper._store.evict_to_cpu.assert_called_once_with(0, layer)
+        self.assertEqual(wrapper._resident_understanding_layers, set())
+        self.assertEqual(wrapper._resident_understanding_bytes, 0)
+        self.assertEqual(wrapper._prefix_attention_reserve_bytes, 0)
+        self.assertFalse(wrapper._prefix_residency_active)
 
     def test_prefix_weight_store_reuses_pinned_cpu_backing(self) -> None:
         source = Mock()
@@ -260,6 +339,121 @@ class LayerOffloadPartitionTest(unittest.TestCase):
             _resident_memory_limit(24 * gib, headroom_bytes=-1)
         with self.assertRaises(ValueError):
             _resident_memory_limit(24 * gib, budget_bytes=0)
+
+    def test_cuda_malloc_async_does_not_treat_cross_stream_cache_as_free(self) -> None:
+        gib = 1024**3
+        wrapper = object.__new__(LayerOffloadWrapper)
+        nn.Module.__init__(wrapper)
+        wrapper._target_device = torch.device("cuda")
+        wrapper._resident_headroom_bytes = 2 * gib
+        wrapper._resident_memory_limit_bytes = 72 * gib
+        wrapper._cuda_malloc_async = True
+        wrapper._accel = Mock()
+        wrapper._accel.memory_allocated.return_value = 30 * gib
+        wrapper._accel.memory_reserved.return_value = 60 * gib
+        wrapper._accel.mem_get_info.return_value = (1 * gib, 80 * gib)
+
+        self.assertFalse(LayerOffloadWrapper._can_keep_resident(wrapper, 4 * gib))
+
+    def test_thinking_residency_waits_for_incremental_prefix_forward(self) -> None:
+        wrapper = object.__new__(LayerOffloadWrapper)
+        nn.Module.__init__(wrapper)
+        wrapper._keep_generation_resident = True
+        wrapper._inference_phase = "prefix"
+        wrapper._prefix_attention_reserve_bytes = 0
+        wrapper._prefix_residency_active = False
+
+        LayerOffloadWrapper._observe_prefix_forward(
+            wrapper,
+            query_length=8442,
+            key_length=8442,
+            batch_size=1,
+            num_heads=32,
+        )
+
+        self.assertEqual(wrapper._prefix_attention_reserve_bytes, 27_366_667_776)
+        self.assertFalse(wrapper._prefix_residency_active)
+
+        LayerOffloadWrapper._observe_prefix_forward(
+            wrapper,
+            query_length=1,
+            key_length=9305,
+            batch_size=1,
+            num_heads=32,
+        )
+
+        self.assertEqual(wrapper._prefix_attention_reserve_bytes, 27_366_667_776)
+        self.assertTrue(wrapper._prefix_residency_active)
+
+    def test_thinking_residency_keeps_only_understanding_weights_within_budget(self) -> None:
+        gib = 1024**3
+        wrapper = object.__new__(LayerOffloadWrapper)
+        nn.Module.__init__(wrapper)
+        wrapper._keep_generation_resident = True
+        wrapper._inference_phase = "prefix"
+        wrapper._prefix_residency_active = True
+        wrapper._prefix_attention_reserve_bytes = 25 * gib
+        wrapper._activation_reserve_bytes = 4 * gib
+        wrapper._resident_headroom_bytes = 2 * gib
+        wrapper._resident_memory_limit_bytes = 72 * gib
+        wrapper._resident_understanding_layers = set()
+        wrapper._resident_understanding_bytes = 0
+        wrapper._target_device = torch.device("cuda")
+        wrapper._accel = Mock()
+        wrapper._accel.memory_allocated.return_value = 30 * gib
+        wrapper._accel.memory_reserved.return_value = 32 * gib
+        wrapper._accel.mem_get_info.return_value = (48 * gib, 80 * gib)
+        wrapper._store = Mock()
+        wrapper._store.group_nbytes.return_value = 1 * gib
+        groups = frozenset({_GROUP_SHARED, _GROUP_UNDERSTANDING})
+
+        groups_to_evict = LayerOffloadWrapper._understanding_groups_to_evict(wrapper, 3, groups)
+
+        self.assertEqual(groups_to_evict, frozenset({_GROUP_SHARED}))
+        self.assertEqual(wrapper._resident_understanding_layers, {3})
+        self.assertEqual(wrapper._resident_understanding_bytes, 1 * gib)
+
+        wrapper._accel.memory_allocated.return_value = 50 * gib
+        groups_to_evict = LayerOffloadWrapper._understanding_groups_to_evict(wrapper, 3, groups)
+
+        self.assertEqual(groups_to_evict, groups)
+        self.assertEqual(wrapper._resident_understanding_layers, set())
+        self.assertEqual(wrapper._resident_understanding_bytes, 0)
+
+    def test_layer_hooks_observe_incremental_prefix_and_apply_understanding_residency(self) -> None:
+        layer = _HookableTwoBranchLayer()
+        wrapper = object.__new__(LayerOffloadWrapper)
+        nn.Module.__init__(wrapper)
+        wrapper._layers = nn.ModuleList([layer])
+        wrapper._hooks = []
+        wrapper._async_mode = False
+        wrapper._store = Mock()
+        wrapper._observe_prefix_forward = Mock()
+        groups = frozenset({_GROUP_SHARED, _GROUP_UNDERSTANDING})
+        wrapper._understanding_groups_to_evict = Mock(return_value=frozenset({_GROUP_SHARED}))
+        wrapper._generation_groups_to_evict = Mock(return_value=frozenset({_GROUP_SHARED}))
+
+        LayerOffloadWrapper._register_hooks(wrapper)
+        layer(
+            torch.zeros(2, 1, 4),
+            exist_non_image_gen_tokens=True,
+            exist_image_gen_tokens=False,
+            attention_mask=torch.zeros(2, 1, 1, 10),
+        )
+
+        wrapper._observe_prefix_forward.assert_called_once_with(
+            query_length=1,
+            key_length=10,
+            batch_size=2,
+            num_heads=4,
+        )
+        wrapper._understanding_groups_to_evict.assert_called_once_with(0, groups)
+        wrapper._generation_groups_to_evict.assert_called_once_with(0, frozenset({_GROUP_SHARED}))
+        wrapper._store.evict_to_cpu.assert_called_once_with(
+            0,
+            layer,
+            groups=frozenset({_GROUP_SHARED}),
+        )
 
     def test_offload_cli_exposes_fast_mode_budget_controls(self) -> None:
         parser = argparse.ArgumentParser()

--- a/tests/test_think_inference.py
+++ b/tests/test_think_inference.py
@@ -1,0 +1,55 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from sensenova_u1.models.neo_unify.modeling_neo_chat import NEOChatModel
+
+
+class ThinkInferenceTest(unittest.TestCase):
+    def test_initial_think_forward_only_computes_last_token_logits(self) -> None:
+        language_model = Mock()
+        model = SimpleNamespace(language_model=language_model)
+        input_ids = torch.tensor([[1, 2, 3]])
+        indexes = torch.zeros(3, 3, dtype=torch.long)
+        attention_mask = {"full_attention": torch.zeros(1, 1, 3, 3)}
+
+        NEOChatModel._think_prefix_forward(
+            model,
+            input_ids=input_ids,
+            indexes=indexes,
+            attention_mask=attention_mask,
+        )
+
+        language_model.assert_called_once_with(
+            input_ids=input_ids,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            use_cache=True,
+            logits_to_keep=1,
+        )
+
+    def test_appending_fixed_text_updates_cache_without_lm_head(self) -> None:
+        backbone = Mock()
+        embeddings = Mock(return_value=torch.zeros(1, 2, 4))
+        language_model = Mock()
+        language_model.model = backbone
+        language_model.get_input_embeddings.return_value = embeddings
+        model = SimpleNamespace(language_model=language_model)
+        cache = Mock()
+        cache.get_seq_length.return_value = 7
+        input_ids = torch.tensor([[5, 6]])
+
+        next_index = NEOChatModel._append_text_tokens_to_cache(model, cache, 9, input_ids)
+
+        self.assertEqual(next_index, 11)
+        backbone.assert_called_once()
+        language_model.assert_not_called()
+        call_kwargs = backbone.call_args.kwargs
+        self.assertIs(call_kwargs["past_key_values"], cache)
+        self.assertTrue(call_kwargs["use_cache"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Keep the understanding branch resident during incremental Think forwards when it fits the existing `fast` VRAM budget; the initial long-prefix forward remains streamed.
- Evict understanding and prefix-only weights before loading the generation branch, including interrupted-run retry and synchronous-offload paths.
- Compute only the final prefix-token logits and bypass the unused LM head when appending fixed Think text.
- Keep the public VRAM modes and ComfyUI workflow inputs unchanged. Non-Think inference continues to use the previous execution path.

## Performance

H100 80 GB, SenseNova-U1.5-8B-MoT-Preview, BF16, effective Flash Attention, batch 1, 2048x2048 output, 50 steps, seed 42. Generation times exclude model loading and are single measured invocations without warmup.

`Peak allocated` is live PyTorch tensor memory. `Peak reserved` is the highest PyTorch allocator-pool size and includes allocated tensors plus cached blocks; it is the more conservative of the two when estimating required card capacity, but still excludes CUDA context and non-PyTorch allocations.

| Task / mode | Generation time | Peak allocated / reserved VRAM |
|---|---:|---:|
| T2I, old `fast --think` | 135.948 s | 17.42 / 17.89 GiB |
| T2I, new `fast --think` | **93.404 s (-31.3%)** | 17.72 / 18.26 GiB |
| Two-reference Edit, `full --think` reference | 96.240 s | 56.51 / 60.07 GiB |
| Two-reference Edit, old `fast --think` | 324.552 s | 27.40 / 44.60 GiB |
| Two-reference Edit, new `fast --think` | **182.621 s (-43.7% vs old fast)** | 41.42 / 44.97 GiB |

For Edit, the new fast path intentionally uses 14.02 GiB more peak allocated memory than the old fast path to avoid repeated Think-branch transfers; peak reserved increases by only 0.37 GiB. Compared with `full`, the new fast path still reduces peak allocated by 15.09 GiB and peak reserved by 15.10 GiB.

### 40.5 GiB explicit-budget validation

The same two-reference Edit case was also run with:

```text
--vram_mode fast
--fast_vram_budget_gib 40.5
--fast_vram_headroom_gib 2.0
--fast_activation_reserve_gib 4.0
--think
--input_max_pixels 4194304
--width 2048 --height 2048
--num_steps 50 --seed 42
```

An explicit `fast_vram_budget_gib` overrides the default `fast_vram_fraction=0.9` residency watermark.

| Generation time | Peak allocated | Peak reserved | Output |
|---:|---:|---:|---|
| **223.143 s** | **35.90 GiB** | **44.60 GiB** | Exact PNG and Think-text hash match |

This was an explicit-budget run on an 80 GB H100, not a physical 45 GB/MIG-card test. The 40.5 GiB value controls residency decisions against projected allocated memory; it is not a hard cap on `reserved` or external `nvidia-smi` usage. A physical 45 GB device remains close to the observed 44.60 GiB reserved watermark and needs additional CUDA-runtime headroom.

All old/new T2I and Edit PNG hashes match exactly; generated Think-text hashes also match exactly.

## Why

`fast` previously retained generation weights during denoising, but every autoregressive Think token still streamed the understanding branch from CPU. The new phase-aware policy begins residency only after the memory-heavy full-prefix forward and releases it before generation weights are loaded.

## Validation

- `44 passed`
- pre-commit: Ruff import/format and ComfyUI workflow formatting passed
- GitNexus change impact: low risk
- adversarial standards/spec review: no remaining blocker or should-fix
