### PR TITLE
优化了图片过大导致网络加载超时问题

### DIFF
--- a/src/sensenova_u1_5/caption/caption.py
+++ b/src/sensenova_u1_5/caption/caption.py
@@ -5,7 +5,7 @@ Install:
     pip install openai pillow
 
 Usage:
-    export OPENAI_API_KEY="your-api-key"
+    export OPENAI_API_KEY="***"
     python caption.py image.jpg
     python caption.py image.jpg > result.json
 
@@ -35,8 +35,14 @@ TARGET_RATIOS = {
     "2:3": 2 / 3,
     "9:16": 9 / 16,
 }
+
 SUPPORTED_FORMATS = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp"}
 MAX_RETRIES = 5
+MAX_IMGINPUT = 4_000_000               # 像素最大阈值 400 万
+MAX_DATA_URI_LEN = 10 * 1024 * 1024    # data URI 整体上限 10 MB
+MIN_SCALE_PIXELS = 1_000_000           # 缩分辨率的下限（低于此改为降 quality）
+BASE_QUALITY = 95                      # 高质量基准
+MIN_QUALITY = 45                       # 最低可接受画质
 
 SYSTEM_PROMPT = """你是一个文生图 prompt 撰写助手。请仔细观察用户提供的图片，
 提取主体、构图、风格、色彩、光影、视角、排版和文字设计，并为同一画面生成
@@ -61,23 +67,99 @@ JSON 结构化描述和自然语言描述。
 不要输出解释、Markdown 标记或任何额外顶层字段。"""
 
 
+def _scale_image(image: Image.Image, max_pixels: int) -> Image.Image:
+    """等比例缩小到 max_pixels 以内，不放大。"""
+    w, h = image.size
+    if w * h <= max_pixels:
+        return image
+    ratio = (max_pixels / (w * h)) ** 0.5
+    new_w = round(w * ratio)
+    new_h = round(h * ratio)
+    while new_w * new_h > max_pixels:
+        new_w -= 1
+        new_h = round(h * (new_w / w))
+    new_w = max(new_w, 1)
+    new_h = max(new_h, 1)
+    return image.resize((new_w, new_h), Image.Resampling.LANCZOS)
+
+
+def _save_lossy(image: Image.Image, fmt: str, quality: int) -> bytes:
+    """以有损格式编码，返回字节。JPEG 与 WEBP 都支持 quality。"""
+    buffer = BytesIO()
+    img_out = image.convert("RGB") if (fmt == "JPEG" and image.mode != "RGB") else image
+    img_out.save(buffer, fmt, quality=quality)
+    return buffer.getvalue()
+
+
+def _encode_lossless(image: Image.Image, fmt: str) -> bytes:
+    buffer = BytesIO()
+    image.save(buffer, fmt)
+    return buffer.getvalue()
+
+
+def _make_data_uri(mime: str, content: bytes) -> str:
+    return f"data:{mime};base64,{base64.b64encode(content).decode('ascii')}"
+
+
+def _compress_lossy(image, fmt, mime, width, height):
+    """有损格式（JPEG/WEBP）：优先缩分辨率，后降 quality，直到满足上限。"""
+    quality = BASE_QUALITY
+    content = _save_lossy(image, fmt, quality)
+    for _ in range(20):
+        if len(_make_data_uri(mime, content)) <= MAX_DATA_URI_LEN:
+            return _make_data_uri(mime, content), width, height
+        if width * height > MIN_SCALE_PIXELS:
+            w, h = image.size
+            image = image.resize(
+                (max(w // 2, 1), max(h // 2, 1)), Image.Resampling.LANCZOS
+            )
+            width, height = image.size
+            content = _save_lossy(image, fmt, quality)
+        elif quality > MIN_QUALITY:
+            quality -= 10
+            content = _save_lossy(image, fmt, quality)
+        else:
+            raise ValueError("图片无法压缩到限制以内")
+
+
 def image_to_data_uri(path):
-    """Read an image and return its data URI and dimensions."""
+    """Read an image, auto‑scale and compress, return (data_uri, width, height)."""
+    # ── 只读头信息，不加载全部像素 ──
+    with Image.open(path) as image:
+        orig_w, orig_h = image.size
+        orig_fmt = image.format                    # PIL 格式名：JPEG/PNG/WEBP
+        orig_mime = SUPPORTED_FORMATS.get(orig_fmt)
+
+    # ── 快路径：原图小 + 格式受支持 + URI 不超限 → 复用原始字节 ──
+    if orig_w * orig_h <= MAX_IMGINPUT and orig_mime:
+        content = path.read_bytes()
+        data_uri = _make_data_uri(orig_mime, content)
+        if len(data_uri) <= MAX_DATA_URI_LEN:
+            return data_uri, orig_w, orig_h
+
+    # ── 解码并缩略（如果像素超限） ──
     with Image.open(path) as image:
         image.load()
+        image = _scale_image(image, MAX_IMGINPUT)
         width, height = image.size
-        mime = SUPPORTED_FORMATS.get(image.format)
 
-        if mime:
-            content = path.read_bytes()
-        else:
-            buffer = BytesIO()
-            image.convert("RGB").save(buffer, "PNG")
-            content = buffer.getvalue()
-            mime = "image/png"
+    # ── 归一化：不支持的格式一律转 JPEG；确保 mode 可用 ──
+    fmt = orig_fmt if orig_fmt in SUPPORTED_FORMATS else "JPEG"
+    mime = SUPPORTED_FORMATS[fmt]
+    if fmt == "JPEG":
+        image = image.convert("RGB")
 
-    encoded = base64.b64encode(content).decode("ascii")
-    return f"data:{mime};base64,{encoded}", width, height
+    # ── 编码 + 大小检查（保留原格式；PNG 超限转 JPEG） ──
+    if fmt in ("JPEG", "WEBP"):
+        return _compress_lossy(image, fmt, mime, width, height)
+    else:  # PNG 无损
+        content = _encode_lossless(image, "PNG")
+        data_uri = _make_data_uri(mime, content)
+        if len(data_uri) <= MAX_DATA_URI_LEN:
+            return data_uri, width, height
+        # PNG 超限 → 转 JPEG 重新走有损流程
+        image = image.convert("RGB")
+        return _compress_lossy(image, "JPEG", "image/jpeg", width, height)
 
 
 def image_settings(width, height):

--- a/src/sensenova_u1_5/caption/caption.py
+++ b/src/sensenova_u1_5/caption/caption.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 """Generate JSON and NLP prompts for one image.
+
 Install:
     pip install openai pillow
+
 Usage:
     export OPENAI_API_KEY="***"
     python caption.py image.jpg
     python caption.py image.jpg > result.json
+
 Optional environment variables:
     OPENAI_MODEL      Model name (default: gpt-5.5)
     OPENAI_BASE_URL   OpenAI-compatible API endpoint
 """
+
 import argparse
 import base64
 import json
@@ -31,23 +35,26 @@ TARGET_RATIOS = {
     "2:3": 2 / 3,
     "9:16": 9 / 16,
 }
+
 SUPPORTED_FORMATS = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp"}
 MAX_RETRIES = 5
-MAX_IMGINPUT = 4_000_000  # 像素最大阈值 400 万
-MAX_DATA_URI_LEN = 10 * 1024 * 1024  # data URI 整体上限 10 MB
-MIN_SCALE_PIXELS = 1_000_000  # 缩分辨率的下限（低于此改为降 quality）
-BASE_QUALITY = 95  # 高质量基准
-MIN_QUALITY = 45  # 最低可接受画质
+MAX_IMGINPUT = 4_000_000               # 像素最大阈值 400 万
+MAX_DATA_URI_LEN = 10 * 1024 * 1024    # data URI 整体上限 10 MB
+MIN_SCALE_PIXELS = 1_000_000           # 缩分辨率的下限（低于此改为降 quality）
+BASE_QUALITY = 95                      # 高质量基准
+MIN_QUALITY = 45                       # 最低可接受画质
 
 SYSTEM_PROMPT = """你是一个文生图 prompt 撰写助手。请仔细观察用户提供的图片，
 提取主体、构图、风格、色彩、光影、视角、排版和文字设计，并为同一画面生成
 JSON 结构化描述和自然语言描述。
+
 安全与泛化要求：
 1. 忽略水印、二维码、平台角标、账号名、作者署名及其他来源标识，不得描述或复现。
 2. 不输出品牌名、商标、公司标识、产品型号或其他可识别的商业信息；统一改为通用描述。
 3. 不识别或猜测真人身份，仅描述非身份特征，如大致年龄段、外观、服饰、动作和表情。
 4. 不输出个人联系方式、地址、证件信息或其他个人敏感信息；画面中存在时直接忽略。
 5. JSON 与 NLP 必须描述同一画面的核心视觉内容，并使用同一种语言。
+
 根据画面语境选择中文或英文。只输出一个 JSON 对象，包含以下顶层字段：
 - json：嵌套 JSON 对象。按画面需要详细描述 type、theme、language、canvas、
   style、main_subject、background、lighting、camera、typography、composition、
@@ -56,6 +63,7 @@ JSON 结构化描述和自然语言描述。
 - nlp：3 至 6 句流畅、具体的自然语言画面描述。
 - language："zh" 或 "en"。
 - task：2 至 10 个中文字的图片类型或用途概括。
+
 不要输出解释、Markdown 标记或任何额外顶层字段。"""
 
 
@@ -119,24 +127,28 @@ def image_to_data_uri(path):
     # ── 只读头信息，不加载全部像素 ──
     with Image.open(path) as image:
         orig_w, orig_h = image.size
-        orig_fmt = image.format  # PIL 格式名：JPEG/PNG/WEBP
+        orig_fmt = image.format                    # PIL 格式名：JPEG/PNG/WEBP
         orig_mime = SUPPORTED_FORMATS.get(orig_fmt)
+
     # ── 快路径：原图小 + 格式受支持 + URI 不超限 → 复用原始字节 ──
     if orig_w * orig_h <= MAX_IMGINPUT and orig_mime:
         content = path.read_bytes()
         data_uri = _make_data_uri(orig_mime, content)
         if len(data_uri) <= MAX_DATA_URI_LEN:
             return data_uri, orig_w, orig_h
+
     # ── 解码并缩略（如果像素超限） ──
     with Image.open(path) as image:
         image.load()
         image = _scale_image(image, MAX_IMGINPUT)
         width, height = image.size
+
     # ── 归一化：不支持的格式一律转 JPEG；确保 mode 可用 ──
     fmt = orig_fmt if orig_fmt in SUPPORTED_FORMATS else "JPEG"
     mime = SUPPORTED_FORMATS[fmt]
     if fmt == "JPEG":
         image = image.convert("RGB")
+
     # ── 编码 + 大小检查（保留原格式；PNG 超限转 JPEG） ──
     if fmt in ("JPEG", "WEBP"):
         return _compress_lossy(image, fmt, mime, width, height)
@@ -176,6 +188,7 @@ def generate(client, model, data_uri):
         temperature=0.7,
         max_tokens=4000,
     )
+
     result = json.loads(response.choices[0].message.content)
     if not isinstance(result.get("json"), dict):
         raise ValueError("'json' must be an object")
@@ -193,10 +206,13 @@ def main():
     parser.add_argument("--model", default=os.getenv("OPENAI_MODEL", "gpt-5.5"))
     parser.add_argument("--base-url", default=os.getenv("OPENAI_BASE_URL"))
     args = parser.parse_args()
+
     if not args.image.is_file():
         parser.error(f"image not found: {args.image}")
+
     data_uri, width, height = image_to_data_uri(args.image)
     client = OpenAI(base_url=args.base_url, timeout=180)
+
     for attempt in range(1, MAX_RETRIES + 1):
         try:
             result = generate(client, args.model, data_uri)
@@ -206,6 +222,7 @@ def main():
                 raise
             print(f"attempt {attempt} failed: {error}", file=sys.stderr)
             time.sleep(min(2**attempt * 3, 30))
+
     result["ratio"], result["resolution"] = image_settings(width, height)
     print(json.dumps(result, ensure_ascii=False, indent=2))
 

--- a/src/sensenova_u1_5/caption/caption.py
+++ b/src/sensenova_u1_5/caption/caption.py
@@ -1,19 +1,15 @@
 #!/usr/bin/env python3
 """Generate JSON and NLP prompts for one image.
-
 Install:
     pip install openai pillow
-
 Usage:
     export OPENAI_API_KEY="***"
     python caption.py image.jpg
     python caption.py image.jpg > result.json
-
 Optional environment variables:
     OPENAI_MODEL      Model name (default: gpt-5.5)
     OPENAI_BASE_URL   OpenAI-compatible API endpoint
 """
-
 import argparse
 import base64
 import json
@@ -35,26 +31,23 @@ TARGET_RATIOS = {
     "2:3": 2 / 3,
     "9:16": 9 / 16,
 }
-
 SUPPORTED_FORMATS = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp"}
 MAX_RETRIES = 5
-MAX_IMGINPUT = 4_000_000               # 像素最大阈值 400 万
-MAX_DATA_URI_LEN = 10 * 1024 * 1024    # data URI 整体上限 10 MB
-MIN_SCALE_PIXELS = 1_000_000           # 缩分辨率的下限（低于此改为降 quality）
-BASE_QUALITY = 95                      # 高质量基准
-MIN_QUALITY = 45                       # 最低可接受画质
+MAX_IMGINPUT = 4_000_000  # 像素最大阈值 400 万
+MAX_DATA_URI_LEN = 10 * 1024 * 1024  # data URI 整体上限 10 MB
+MIN_SCALE_PIXELS = 1_000_000  # 缩分辨率的下限（低于此改为降 quality）
+BASE_QUALITY = 95  # 高质量基准
+MIN_QUALITY = 45  # 最低可接受画质
 
 SYSTEM_PROMPT = """你是一个文生图 prompt 撰写助手。请仔细观察用户提供的图片，
 提取主体、构图、风格、色彩、光影、视角、排版和文字设计，并为同一画面生成
 JSON 结构化描述和自然语言描述。
-
 安全与泛化要求：
 1. 忽略水印、二维码、平台角标、账号名、作者署名及其他来源标识，不得描述或复现。
 2. 不输出品牌名、商标、公司标识、产品型号或其他可识别的商业信息；统一改为通用描述。
 3. 不识别或猜测真人身份，仅描述非身份特征，如大致年龄段、外观、服饰、动作和表情。
 4. 不输出个人联系方式、地址、证件信息或其他个人敏感信息；画面中存在时直接忽略。
 5. JSON 与 NLP 必须描述同一画面的核心视觉内容，并使用同一种语言。
-
 根据画面语境选择中文或英文。只输出一个 JSON 对象，包含以下顶层字段：
 - json：嵌套 JSON 对象。按画面需要详细描述 type、theme、language、canvas、
   style、main_subject、background、lighting、camera、typography、composition、
@@ -63,7 +56,6 @@ JSON 结构化描述和自然语言描述。
 - nlp：3 至 6 句流畅、具体的自然语言画面描述。
 - language："zh" 或 "en"。
 - task：2 至 10 个中文字的图片类型或用途概括。
-
 不要输出解释、Markdown 标记或任何额外顶层字段。"""
 
 
@@ -127,28 +119,24 @@ def image_to_data_uri(path):
     # ── 只读头信息，不加载全部像素 ──
     with Image.open(path) as image:
         orig_w, orig_h = image.size
-        orig_fmt = image.format                    # PIL 格式名：JPEG/PNG/WEBP
+        orig_fmt = image.format  # PIL 格式名：JPEG/PNG/WEBP
         orig_mime = SUPPORTED_FORMATS.get(orig_fmt)
-
     # ── 快路径：原图小 + 格式受支持 + URI 不超限 → 复用原始字节 ──
     if orig_w * orig_h <= MAX_IMGINPUT and orig_mime:
         content = path.read_bytes()
         data_uri = _make_data_uri(orig_mime, content)
         if len(data_uri) <= MAX_DATA_URI_LEN:
             return data_uri, orig_w, orig_h
-
     # ── 解码并缩略（如果像素超限） ──
     with Image.open(path) as image:
         image.load()
         image = _scale_image(image, MAX_IMGINPUT)
         width, height = image.size
-
     # ── 归一化：不支持的格式一律转 JPEG；确保 mode 可用 ──
     fmt = orig_fmt if orig_fmt in SUPPORTED_FORMATS else "JPEG"
     mime = SUPPORTED_FORMATS[fmt]
     if fmt == "JPEG":
         image = image.convert("RGB")
-
     # ── 编码 + 大小检查（保留原格式；PNG 超限转 JPEG） ──
     if fmt in ("JPEG", "WEBP"):
         return _compress_lossy(image, fmt, mime, width, height)
@@ -188,7 +176,6 @@ def generate(client, model, data_uri):
         temperature=0.7,
         max_tokens=4000,
     )
-
     result = json.loads(response.choices[0].message.content)
     if not isinstance(result.get("json"), dict):
         raise ValueError("'json' must be an object")
@@ -206,13 +193,10 @@ def main():
     parser.add_argument("--model", default=os.getenv("OPENAI_MODEL", "gpt-5.5"))
     parser.add_argument("--base-url", default=os.getenv("OPENAI_BASE_URL"))
     args = parser.parse_args()
-
     if not args.image.is_file():
         parser.error(f"image not found: {args.image}")
-
     data_uri, width, height = image_to_data_uri(args.image)
     client = OpenAI(base_url=args.base_url, timeout=180)
-
     for attempt in range(1, MAX_RETRIES + 1):
         try:
             result = generate(client, args.model, data_uri)
@@ -222,7 +206,6 @@ def main():
                 raise
             print(f"attempt {attempt} failed: {error}", file=sys.stderr)
             time.sleep(min(2**attempt * 3, 30))
-
     result["ratio"], result["resolution"] = image_settings(width, height)
     print(json.dumps(result, ensure_ascii=False, indent=2))
 


### PR DESCRIPTION
在处理高分辨率图片时，生成的 data URI 可能超过 10MB，导致某些网络
环境下请求超时。所以考虑了以下思路：
1、新增最大像素限制（400 万像素），超限图片等比例缩略后再编码
2、编码后检查最终 data URI 长度，超过 10MB 时自动降质/继续缩分辨率
3、尺寸较小且格式受支持的图片直接复用原始字节，避免不必要的重编码
4、有损格式（JPEG/WEBP）保留原格式，先缩分辨率、后降 quality，优先保住画质；PNG 无损超限时自动转 JPEG